### PR TITLE
Нормализовать размер 3D лейблов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T12:26:40.291Z for PR creation at branch issue-7-fe9ebb32701c for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/7

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T12:26:40.291Z for PR creation at branch issue-7-fe9ebb32701c for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/7

--- a/experiments/label-scale-regression.mjs
+++ b/experiments/label-scale-regression.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { calculateLabelScaleForCamera } from '../wwwroot/js/label-scale.js';
+
+const cameraFov = 75;
+const viewportHeight = 600;
+const labelAspectRatio = 4;
+const targetPixelHeight = 34;
+
+const nearScale = calculateLabelScaleForCamera(1, cameraFov, viewportHeight, labelAspectRatio, targetPixelHeight);
+const farScale = calculateLabelScaleForCamera(4, cameraFov, viewportHeight, labelAspectRatio, targetPixelHeight);
+
+assert.ok(nearScale.height > 0, 'near label height should be positive');
+assert.ok(farScale.height > nearScale.height, 'far label should get larger world scale to preserve screen size');
+assert.equal(Math.round((farScale.height / nearScale.height) * 100) / 100, 4);
+assert.equal(Math.round((farScale.width / nearScale.width) * 100) / 100, 4);
+assert.equal(Math.round((nearScale.width / nearScale.height) * 100) / 100, labelAspectRatio);
+
+console.log('Label scale regression checks passed');

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -1,6 +1,7 @@
 // wwwroot/js/community-globe.js
 //import * as THREE from './libs/three.module.js';
 //import { OrbitControls } from './libs/OrbitControls.js';
+import { DEFAULT_LABEL_PIXEL_HEIGHT, calculateLabelScaleForCamera } from './label-scale.js';
 
 // Глобальные переменные для библиотек
 let THREE, OrbitControls;
@@ -127,6 +128,7 @@ class CommunityGlobe {
         this.clouds = null;
         this.participantPoints = [];
         this.participantLabels = [];
+        this.labelTargetPixelHeight = DEFAULT_LABEL_PIXEL_HEIGHT;
         this.countryPolygons = [];
         this.raycaster = null;
         this.mouse = { x: 0, y: 0 };
@@ -670,7 +672,9 @@ class CommunityGlobe {
                 const radius = 1 + this.options.participantPointOffset + 0.03;
                 const position = this.latLngToVector3(participant.latitude, participant.longitude, radius);
                 sprite.position.set(position.x, position.y, position.z);
-                sprite.scale.set(0.2, 0.1, 1);
+                sprite.userData.labelAspectRatio = canvas.width / canvas.height;
+                sprite.userData.targetPixelHeight = this.labelTargetPixelHeight;
+                this.updateParticipantLabelScale(sprite);
 
                 this.earthGroup.add(sprite);
                 this.participantLabels.push(sprite);
@@ -682,6 +686,26 @@ class CommunityGlobe {
         });
 
         console.log(`✅ Создано ${this.participantLabels.length} меток участников`);
+    }
+
+    updateParticipantLabelScale(label) {
+        if (!this.camera || !this.renderer || !label) return;
+
+        const distanceToCamera = label.getWorldPosition(new THREE.Vector3()).distanceTo(this.camera.position);
+        const rendererSize = this.renderer.getSize(new THREE.Vector2());
+        const scale = calculateLabelScaleForCamera(
+            distanceToCamera,
+            this.camera.fov,
+            rendererSize.height,
+            label.userData.labelAspectRatio,
+            label.userData.targetPixelHeight
+        );
+
+        label.scale.set(scale.width, scale.height, 1);
+    }
+
+    updateParticipantLabelScales() {
+        this.participantLabels.forEach(label => this.updateParticipantLabelScale(label));
     }
 
     animate() {
@@ -701,6 +725,7 @@ class CommunityGlobe {
         }
 
         if (this.controls) this.controls.update();
+        this.updateParticipantLabelScales();
         this.updateCameraState();
         this.renderer.render(this.scene, this.camera);
     }

--- a/wwwroot/js/label-scale.js
+++ b/wwwroot/js/label-scale.js
@@ -1,0 +1,14 @@
+export const DEFAULT_LABEL_PIXEL_HEIGHT = 34;
+
+export function calculateLabelScaleForCamera(distanceToCamera, cameraFovDegrees, viewportHeight, labelAspectRatio, targetPixelHeight = DEFAULT_LABEL_PIXEL_HEIGHT) {
+    const safeDistance = Math.max(Number(distanceToCamera) || 0, 0.0001);
+    const safeViewportHeight = Math.max(Number(viewportHeight) || 0, 1);
+    const safeAspectRatio = Math.max(Number(labelAspectRatio) || 1, 0.01);
+    const safePixelHeight = Math.max(Number(targetPixelHeight) || DEFAULT_LABEL_PIXEL_HEIGHT, 1);
+    const fovRadians = (Number(cameraFovDegrees) || 75) * Math.PI / 180;
+    const visibleHeightAtDistance = 2 * safeDistance * Math.tan(fovRadians / 2);
+    const worldHeight = visibleHeightAtDistance * safePixelHeight / safeViewportHeight;
+    const worldWidth = worldHeight * safeAspectRatio;
+
+    return { width: worldWidth, height: worldHeight };
+}


### PR DESCRIPTION
## Summary
- Added camera-aware scaling for participant label sprites on the Three.js globe.
- Moved the label scale calculation into a small reusable JS helper.
- Added a Node regression check proving label world scale grows proportionally with camera distance, keeping screen size stable.

Fixes MiheevN/ZealousGeoLibrary#7

## Testing
- `node experiments/label-scale-regression.mjs`
- `node --check experiments/label-scale-regression.mjs`
- `node --check wwwroot/js/label-scale.js`
- `node --check wwwroot/js/community-globe.js`

## Notes
- `dotnet build ZealousMindedPeopleGeo.csproj` could not run in this environment because the installed SDK is 8.0.125 while the project targets `net10.0` (`NETSDK1045`).
