### PR TITLE
Останавливать вращение глобуса при взаимодействии

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T12:31:33.996Z for PR creation at branch issue-8-5882615f2404 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/8

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T12:31:33.996Z for PR creation at branch issue-8-5882615f2404 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/8

--- a/experiments/community-globe-auto-rotation.test.mjs
+++ b/experiments/community-globe-auto-rotation.test.mjs
@@ -4,10 +4,18 @@ import test from 'node:test';
 
 async function loadCommunityGlobeClass() {
     const source = await readFile(new URL('../wwwroot/js/community-globe.js', import.meta.url), 'utf8');
-    const testSource = source.replace(
-        /initializeDependencies\(\)\.then\(success => \{[\s\S]*?\n\}\);\n\n\/\/ Глобальный реестр/,
-        'dependenciesLoaded = true;\n\n// Глобальный реестр'
-    );
+    const testSource = source
+        .replace(
+            /import \{ DEFAULT_LABEL_PIXEL_HEIGHT, calculateLabelScaleForCamera \} from '\.\/label-scale\.js';\n/,
+            [
+                'const DEFAULT_LABEL_PIXEL_HEIGHT = 34;',
+                'const calculateLabelScaleForCamera = () => ({ width: 1, height: 1 });'
+            ].join('\n')
+        )
+        .replace(
+            /initializeDependencies\(\)\.then\(success => \{[\s\S]*?\n\}\);\n\n\/\/ Глобальный реестр/,
+            'dependenciesLoaded = true;\n\n// Глобальный реестр'
+        );
     const moduleSource = `${testSource}\nexport { CommunityGlobe };\n`;
     const moduleUrl = `data:text/javascript;base64,${Buffer.from(moduleSource).toString('base64')}`;
     const { CommunityGlobe } = await import(moduleUrl);

--- a/experiments/community-globe-auto-rotation.test.mjs
+++ b/experiments/community-globe-auto-rotation.test.mjs
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+async function loadCommunityGlobeClass() {
+    const source = await readFile(new URL('../wwwroot/js/community-globe.js', import.meta.url), 'utf8');
+    const testSource = source.replace(
+        /initializeDependencies\(\)\.then\(success => \{[\s\S]*?\n\}\);\n\n\/\/ Глобальный реестр/,
+        'dependenciesLoaded = true;\n\n// Глобальный реестр'
+    );
+    const moduleSource = `${testSource}\nexport { CommunityGlobe };\n`;
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(moduleSource).toString('base64')}`;
+    const { CommunityGlobe } = await import(moduleUrl);
+
+    return CommunityGlobe;
+}
+
+function createFakeTimers() {
+    let nextTimerId = 1;
+    const timers = new Map();
+
+    return {
+        setTimeout(callback, delay) {
+            const timerId = nextTimerId++;
+            timers.set(timerId, { callback, delay, cancelled: false });
+            return timerId;
+        },
+        clearTimeout(timerId) {
+            const timer = timers.get(timerId);
+            if (timer) {
+                timer.cancelled = true;
+            }
+        },
+        get activeTimers() {
+            return Array.from(timers.values()).filter(timer => !timer.cancelled);
+        },
+        runTimer(timer) {
+            if (!timer.cancelled) {
+                timer.callback();
+            }
+        }
+    };
+}
+
+function createGlobePrototypeInstance(CommunityGlobe) {
+    const globe = Object.create(CommunityGlobe.prototype);
+
+    globe.options = {
+        autoRotate: true,
+        autoRotateResumeDelay: 1200,
+        autoRotateSpeed: 0.1
+    };
+    globe.state = {
+        isAutoRotating: true,
+        isUserInteracting: false
+    };
+    globe.controls = {
+        autoRotate: true,
+        autoRotateSpeed: 0.1
+    };
+
+    return globe;
+}
+
+test('automatic rotation pauses during interaction and resumes after the configured idle delay', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const fakeTimers = createFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globalThis.setTimeout = fakeTimers.setTimeout;
+    globalThis.clearTimeout = fakeTimers.clearTimeout;
+
+    try {
+        globe.initializeAutoRotationInteractionState();
+
+        globe.pauseAutoRotationForInteraction();
+
+        assert.equal(globe.state.isAutoRotating, false);
+        assert.equal(globe.state.isUserInteracting, true);
+        assert.equal(globe.controls.autoRotate, false);
+
+        globe.scheduleAutoRotationResume();
+
+        assert.equal(globe.state.isAutoRotating, false);
+        assert.equal(globe.state.isUserInteracting, false);
+        assert.equal(fakeTimers.activeTimers.length, 1);
+        assert.equal(fakeTimers.activeTimers[0].delay, 1200);
+
+        fakeTimers.runTimer(fakeTimers.activeTimers[0]);
+
+        assert.equal(globe.state.isAutoRotating, true);
+        assert.equal(globe.controls.autoRotate, true);
+        assert.equal(globe.controls.autoRotateSpeed, 0.1);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});
+
+test('a new interaction cancels the pending automatic-rotation resume timer', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const fakeTimers = createFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globalThis.setTimeout = fakeTimers.setTimeout;
+    globalThis.clearTimeout = fakeTimers.clearTimeout;
+
+    try {
+        globe.initializeAutoRotationInteractionState();
+
+        globe.pauseAutoRotationForInteraction();
+        globe.scheduleAutoRotationResume();
+
+        const firstResumeTimer = fakeTimers.activeTimers[0];
+
+        globe.pauseAutoRotationForInteraction();
+        globe.scheduleAutoRotationResume();
+
+        assert.equal(firstResumeTimer.cancelled, true);
+        assert.equal(fakeTimers.activeTimers.length, 1);
+
+        fakeTimers.runTimer(firstResumeTimer);
+
+        assert.equal(globe.state.isAutoRotating, false);
+
+        fakeTimers.runTimer(fakeTimers.activeTimers[0]);
+
+        assert.equal(globe.state.isAutoRotating, true);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});
+
+test('automatic rotation stays disabled when the user turns it off before the idle timer fires', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const fakeTimers = createFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globalThis.setTimeout = fakeTimers.setTimeout;
+    globalThis.clearTimeout = fakeTimers.clearTimeout;
+
+    try {
+        globe.initializeAutoRotationInteractionState();
+
+        globe.pauseAutoRotationForInteraction();
+        globe.scheduleAutoRotationResume();
+        globe.setAutoRotation(false, 0.1);
+
+        assert.equal(fakeTimers.activeTimers.length, 0);
+        assert.equal(globe.options.autoRotate, false);
+        assert.equal(globe.state.isAutoRotating, false);
+        assert.equal(globe.controls.autoRotate, false);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -82,6 +82,7 @@ class CommunityGlobe {
             highlightedPointColor: '#ff6600',
             autoRotate: true,
             autoRotateSpeed: 0.1,
+            autoRotateResumeDelay: 3000,
             enableMouseControls: true,
             enableZoom: true,
             minZoom: 0.5,
@@ -111,6 +112,7 @@ class CommunityGlobe {
         this.state = {
             isInitialized: false,
             isAutoRotating: this.options.autoRotate,
+            isUserInteracting: false,
             currentLod: this.options.levelOfDetail,
             participantCount: 0,
             countryCount: 0,
@@ -133,11 +135,14 @@ class CommunityGlobe {
         this.animationId = null;
         this.clock = null;
         this.pointMetadata = new Map();
+        this.autoRotationResumeTimer = null;
         this.callbacks = { // Инициализация callbacks
             onGlobeReady: null,
             onError: null,
             onParticipantClick: null
         };
+
+        this.initializeAutoRotationInteractionState();
 
         console.log(`🔧 Создание глобуса для контейнера: ${containerId}`);
         this.init();
@@ -420,8 +425,10 @@ class CommunityGlobe {
         this.controls.enableZoom = this.options.enableZoom;
         this.controls.minDistance = this.options.minZoom;
         this.controls.maxDistance = this.options.maxZoom;
-        this.controls.autoRotate = this.options.autoRotate;
+        this.controls.autoRotate = this.state.isAutoRotating;
         this.controls.autoRotateSpeed = this.options.autoRotateSpeed;
+        this.controls.addEventListener('start', () => this.pauseAutoRotationForInteraction());
+        this.controls.addEventListener('end', () => this.scheduleAutoRotationResume());
     }
 
     setupEventListeners() {
@@ -691,7 +698,10 @@ class CommunityGlobe {
         const deltaTime = this.clock.getDelta();
 
         if (this.earthGroup && this.state.isAutoRotating) {
-            this.earthRotation += deltaTime * 0.1;
+            const rotationSpeed = Number.isFinite(Number(this.options.autoRotateSpeed))
+                ? Number(this.options.autoRotateSpeed)
+                : 0.1;
+            this.earthRotation += deltaTime * rotationSpeed;
             this.earthGroup.rotation.y = this.earthRotation;
         }
 
@@ -749,13 +759,69 @@ class CommunityGlobe {
         animate();
     }
 
+    getAutoRotationResumeDelay() {
+        const delay = Number(this.options.autoRotateResumeDelay);
+        return Number.isFinite(delay) && delay >= 0 ? delay : 3000;
+    }
+
+    initializeAutoRotationInteractionState() {
+        this.clearAutoRotationResumeTimer();
+        this.state.isUserInteracting = false;
+    }
+
+    clearAutoRotationResumeTimer() {
+        if (this.autoRotationResumeTimer) {
+            clearTimeout(this.autoRotationResumeTimer);
+            this.autoRotationResumeTimer = null;
+        }
+    }
+
+    applyAutoRotationState(enabled) {
+        const isEnabled = Boolean(enabled);
+        this.state.isAutoRotating = isEnabled;
+
+        if (this.controls) {
+            this.controls.autoRotate = isEnabled;
+            this.controls.autoRotateSpeed = this.options.autoRotateSpeed;
+        }
+    }
+
+    pauseAutoRotationForInteraction() {
+        this.clearAutoRotationResumeTimer();
+        this.state.isUserInteracting = true;
+
+        if (this.options.autoRotate) {
+            this.applyAutoRotationState(false);
+        }
+    }
+
+    scheduleAutoRotationResume() {
+        this.clearAutoRotationResumeTimer();
+        this.state.isUserInteracting = false;
+
+        if (!this.options.autoRotate) {
+            this.applyAutoRotationState(false);
+            return;
+        }
+
+        this.autoRotationResumeTimer = setTimeout(() => {
+            this.autoRotationResumeTimer = null;
+            if (!this.state.isUserInteracting && this.options.autoRotate) {
+                this.applyAutoRotationState(true);
+            }
+        }, this.getAutoRotationResumeDelay());
+    }
+
     setAutoRotation(enabled, speed) {
         try {
-            this.state.isAutoRotating = enabled;
-            if (this.controls) {
-                this.controls.autoRotate = enabled;
-                this.controls.autoRotateSpeed = speed;
+            this.options.autoRotate = Boolean(enabled);
+            const parsedSpeed = Number(speed);
+            if (speed !== undefined && speed !== null && Number.isFinite(parsedSpeed)) {
+                this.options.autoRotateSpeed = parsedSpeed;
             }
+            this.clearAutoRotationResumeTimer();
+            this.state.isUserInteracting = false;
+            this.applyAutoRotationState(this.options.autoRotate);
             return true;
         } catch (error) {
             console.error('Error setting auto rotation:', error);
@@ -915,6 +981,8 @@ class CommunityGlobe {
                 console.log('🗑️ Отмена animation frame');
                 cancelAnimationFrame(this.animationId);
             }
+
+            this.clearAutoRotationResumeTimer();
 
             if (this.controls) {
                 console.log('🗑️ Освобождение controls');


### PR DESCRIPTION
## Summary
- Pause globe auto-rotation when OrbitControls reports user interaction start (click, drag, wheel, touch).
- Resume automatic rotation after the configured idle delay only if auto-rotation is still enabled and no newer interaction happened.
- Cancel pending resumes when auto-rotation is disabled manually, and apply `autoRotateSpeed` to the manual globe rotation loop.
- Add a Node regression test for pause/resume timing and disabled-state behavior.

Fixes MiheevN/ZealousGeoLibrary#8

## Reproduce
Before this change, interacting with the globe did not pause `state.isAutoRotating` or `controls.autoRotate`, so automatic rotation continued through click/drag interaction.

After this change, interaction pauses both rotation paths and resumes after the idle timer only when auto-rotation remains enabled.

## Testing
- `node --test experiments/community-globe-auto-rotation.test.mjs`
- `/tmp/dotnet10/dotnet build ZealousMindedPeopleGeo.csproj`

## Notes
- Installed .NET SDK 10.0.203 under `/tmp/dotnet10` for local verification because the system SDK is 8.0.125 while the project targets `net10.0`.
- The .NET build succeeds with one existing warning in `Services/GoogleSheetsService.cs` about obsolete `GoogleCredential.FromJson`.
