### PR TITLE
Центрирование камеры на метке

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T15:08:04.950Z for PR creation at branch issue-24-d8303a8ae3fe for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/24

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T15:08:04.950Z for PR creation at branch issue-24-d8303a8ae3fe for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/24

--- a/experiments/community-globe-camera.test.mjs
+++ b/experiments/community-globe-camera.test.mjs
@@ -39,6 +39,7 @@ function createGlobePrototypeInstance(CommunityGlobe, options = {}) {
         participantMarkerMinScale: 0.35,
         participantMarkerMaxScale: 1.2,
         participantLabelLoweringDistance: 1.1,
+        participantClickZoom: 1.35,
         ...options
     };
 
@@ -101,4 +102,41 @@ test('participant label anchor lowers toward the marker base near close zoom', a
     assert.equal(round(nearAnchor, 3), round(dimensions.labelGap * nearScale, 3));
     assert.equal(round(farAnchor, 3), round((dimensions.tipHeight + dimensions.bodyHeight + dimensions.labelGap) * farScale, 3));
     assert.ok(nearAnchor < farAnchor, 'close zoom should move label text down from marker end toward marker start');
+});
+
+test('participant marker click centers camera on marker at close zoom', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const participant = {
+        id: 'participant-1',
+        name: 'Test participant',
+        latitude: 55.7558,
+        longitude: 37.6173
+    };
+    let callbackMetadata = null;
+    let centeredCall = null;
+
+    globe.state = { isInitialized: true };
+    globe.callbacks = {
+        onParticipantClick: metadata => {
+            callbackMetadata = metadata;
+        }
+    };
+    globe.getIntersectedParticipantMarker = () => ({
+        userData: { participant }
+    });
+    globe.updateMousePosition = () => {};
+    globe.centerOn = (latitude, longitude, zoom) => {
+        centeredCall = { latitude, longitude, zoom };
+        return true;
+    };
+
+    globe.onMouseClick({});
+
+    assert.deepEqual(callbackMetadata, participant);
+    assert.deepEqual(centeredCall, {
+        latitude: participant.latitude,
+        longitude: participant.longitude,
+        zoom: 1.35
+    });
 });

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -106,6 +106,7 @@ class CommunityGlobe {
             enableZoom: true,
             minZoom: 1.1,
             maxZoom: 4.0,
+            participantClickZoom: 1.35,
             cameraNearPlane: 0.02,
             earthRadius: 1,
             cloudsRadius: 1.01,
@@ -493,7 +494,13 @@ class CommunityGlobe {
 
         const marker = this.getIntersectedParticipantMarker();
         const metadata = marker?.userData?.participant;
-        if (metadata && this.callbacks.onParticipantClick) {
+        if (!metadata) {
+            return;
+        }
+
+        this.centerOnParticipant(metadata);
+
+        if (this.callbacks.onParticipantClick) {
             this.callbacks.onParticipantClick(metadata);
         }
     }
@@ -1244,6 +1251,18 @@ class CommunityGlobe {
         }
     }
 
+    centerOnParticipant(participant) {
+        if (!participant) return false;
+
+        const latitude = this.getFiniteNumber(participant.latitude, NaN);
+        const longitude = this.getFiniteNumber(participant.longitude, NaN);
+        if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+            return false;
+        }
+
+        return this.centerOn(latitude, longitude, this.options.participantClickZoom);
+    }
+
     animateCameraTo(targetPosition, duration = 1000) {
         if (!this.camera) return;
         const startPosition = { ...this.camera.position };
@@ -1449,6 +1468,7 @@ class CommunityGlobe {
                 'cloudsSpeed',
                 'minZoom',
                 'maxZoom',
+                'participantClickZoom',
                 'cameraNearPlane',
                 'cameraSurfaceClearance',
                 'cameraZoomInMinSpeed',


### PR DESCRIPTION
## Summary
- Centers the 3D globe camera on a participant when its marker is clicked
- Uses a close, collision-safe zoom level for marker clicks
- Adds a regression test covering marker click camera centering while preserving participant click callbacks

Fixes MiheevN/ZealousGeoLibrary#24

## Tests
- `node --test experiments/*.test.mjs`
- `dotnet build ZealousMindedPeopleGeo.csproj` *(fails in this runner because installed SDK is 8.0.125 while the project targets net10.0)*