### PR TITLE
Не возобновлять вращение глобуса до ухода курсора

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T15:10:08.202Z for PR creation at branch issue-23-5c832f9dd17c for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/23

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T15:10:08.202Z for PR creation at branch issue-23-5c832f9dd17c for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/23

--- a/experiments/community-globe-auto-rotation.test.mjs
+++ b/experiments/community-globe-auto-rotation.test.mjs
@@ -84,6 +84,7 @@ test('automatic rotation pauses during interaction and resumes after the configu
         globe.initializeAutoRotationInteractionState();
 
         globe.pauseAutoRotationForInteraction();
+        globe.handleGlobePointerLeave();
 
         assert.equal(globe.state.isAutoRotating, false);
         assert.equal(globe.state.isUserInteracting, true);
@@ -107,6 +108,79 @@ test('automatic rotation pauses during interaction and resumes after the configu
     }
 });
 
+test('automatic rotation waits for the pointer to leave after interaction ends', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const fakeTimers = createFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globalThis.setTimeout = fakeTimers.setTimeout;
+    globalThis.clearTimeout = fakeTimers.clearTimeout;
+
+    try {
+        globe.initializeAutoRotationInteractionState();
+        globe.handleGlobePointerEnter();
+
+        globe.pauseAutoRotationForInteraction();
+        globe.scheduleAutoRotationResume();
+
+        assert.equal(globe.state.isAutoRotating, false);
+        assert.equal(globe.state.isUserInteracting, false);
+        assert.equal(globe.state.isPointerOverGlobe, true);
+        assert.equal(fakeTimers.activeTimers.length, 0);
+
+        globe.handleGlobePointerLeave();
+
+        assert.equal(globe.state.isPointerOverGlobe, false);
+        assert.equal(fakeTimers.activeTimers.length, 1);
+
+        fakeTimers.runTimer(fakeTimers.activeTimers[0]);
+
+        assert.equal(globe.state.isAutoRotating, true);
+        assert.equal(globe.controls.autoRotate, true);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});
+
+test('automatic rotation can resume when captured pointer is released outside the globe', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+    const fakeTimers = createFakeTimers();
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    globe.renderer = {
+        domElement: {
+            style: {},
+            getBoundingClientRect: () => ({ left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 })
+        }
+    };
+
+    globalThis.setTimeout = fakeTimers.setTimeout;
+    globalThis.clearTimeout = fakeTimers.clearTimeout;
+
+    try {
+        globe.initializeAutoRotationInteractionState();
+        globe.pauseAutoRotationForInteraction();
+
+        globe.handleGlobePointerRelease({ clientX: 120, clientY: 50 });
+        globe.scheduleAutoRotationResume();
+
+        assert.equal(globe.state.isPointerOverGlobe, false);
+        assert.equal(fakeTimers.activeTimers.length, 1);
+
+        fakeTimers.runTimer(fakeTimers.activeTimers[0]);
+
+        assert.equal(globe.state.isAutoRotating, true);
+    } finally {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+    }
+});
+
 test('a new interaction cancels the pending automatic-rotation resume timer', async () => {
     const CommunityGlobe = await loadCommunityGlobeClass();
     const globe = createGlobePrototypeInstance(CommunityGlobe);
@@ -121,11 +195,13 @@ test('a new interaction cancels the pending automatic-rotation resume timer', as
         globe.initializeAutoRotationInteractionState();
 
         globe.pauseAutoRotationForInteraction();
+        globe.handleGlobePointerLeave();
         globe.scheduleAutoRotationResume();
 
         const firstResumeTimer = fakeTimers.activeTimers[0];
 
         globe.pauseAutoRotationForInteraction();
+        globe.handleGlobePointerLeave();
         globe.scheduleAutoRotationResume();
 
         assert.equal(firstResumeTimer.cancelled, true);
@@ -158,6 +234,7 @@ test('automatic rotation stays disabled when the user turns it off before the id
         globe.initializeAutoRotationInteractionState();
 
         globe.pauseAutoRotationForInteraction();
+        globe.handleGlobePointerLeave();
         globe.scheduleAutoRotationResume();
         globe.setAutoRotation(false, 0.1);
 

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -147,6 +147,7 @@ class CommunityGlobe {
             isInitialized: false,
             isAutoRotating: this.options.autoRotate,
             isUserInteracting: false,
+            isPointerOverGlobe: false,
             currentLod: this.options.levelOfDetail,
             participantCount: 0,
             countryCount: 0,
@@ -482,9 +483,14 @@ class CommunityGlobe {
     }
 
     setupEventListeners() {
-        this.renderer.domElement.addEventListener('click', (event) => this.onMouseClick(event));
-        this.renderer.domElement.addEventListener('mousemove', (event) => this.onMouseMove(event));
-        this.renderer.domElement.addEventListener('wheel', (event) => this.updateCameraZoomSpeedForWheel(event), { capture: true, passive: true });
+        const globeElement = this.renderer.domElement;
+        globeElement.addEventListener('click', (event) => this.onMouseClick(event));
+        globeElement.addEventListener('mousemove', (event) => this.onMouseMove(event));
+        globeElement.addEventListener('pointerenter', () => this.handleGlobePointerEnter());
+        globeElement.addEventListener('pointerleave', () => this.handleGlobePointerLeave());
+        globeElement.addEventListener('pointerup', (event) => this.handleGlobePointerRelease(event));
+        globeElement.addEventListener('pointercancel', () => this.handleGlobePointerLeave());
+        globeElement.addEventListener('wheel', (event) => this.updateCameraZoomSpeedForWheel(event), { capture: true, passive: true });
         window.addEventListener('resize', () => this.onWindowResize());
     }
 
@@ -499,6 +505,7 @@ class CommunityGlobe {
     }
 
     onMouseMove(event) {
+        this.handleGlobePointerEnter();
         this.updateMousePosition(event);
 
         const marker = this.getIntersectedParticipantMarker();
@@ -1276,6 +1283,7 @@ class CommunityGlobe {
     initializeAutoRotationInteractionState() {
         this.clearAutoRotationResumeTimer();
         this.state.isUserInteracting = false;
+        this.state.isPointerOverGlobe = false;
     }
 
     clearAutoRotationResumeTimer() {
@@ -1298,10 +1306,60 @@ class CommunityGlobe {
     pauseAutoRotationForInteraction() {
         this.clearAutoRotationResumeTimer();
         this.state.isUserInteracting = true;
+        this.state.isPointerOverGlobe = true;
 
         if (this.options.autoRotate) {
             this.applyAutoRotationState(false);
         }
+    }
+
+    handleGlobePointerEnter() {
+        this.state.isPointerOverGlobe = true;
+
+        if (this.options.autoRotate && !this.state.isAutoRotating) {
+            this.clearAutoRotationResumeTimer();
+        }
+    }
+
+    handleGlobePointerLeave() {
+        this.state.isPointerOverGlobe = false;
+        this.setHoveredParticipantMarker(null);
+
+        if (this.renderer?.domElement) {
+            this.renderer.domElement.style.cursor = '';
+        }
+
+        if (!this.state.isUserInteracting && this.options.autoRotate && !this.state.isAutoRotating) {
+            this.scheduleAutoRotationResume();
+        }
+    }
+
+    handleGlobePointerRelease(event) {
+        if (this.isPointerEventInsideGlobe(event)) {
+            this.handleGlobePointerEnter();
+            return;
+        }
+
+        this.handleGlobePointerLeave();
+    }
+
+    isPointerEventInsideGlobe(event) {
+        const element = this.renderer?.domElement;
+        if (!element || typeof element.getBoundingClientRect !== 'function') {
+            return true;
+        }
+
+        const clientX = Number(event?.clientX);
+        const clientY = Number(event?.clientY);
+        if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) {
+            return true;
+        }
+
+        const rect = element.getBoundingClientRect();
+        const right = Number.isFinite(rect.right) ? rect.right : rect.left + rect.width;
+        const bottom = Number.isFinite(rect.bottom) ? rect.bottom : rect.top + rect.height;
+
+        return clientX >= rect.left && clientX <= right && clientY >= rect.top && clientY <= bottom;
     }
 
     scheduleAutoRotationResume() {
@@ -1313,9 +1371,13 @@ class CommunityGlobe {
             return;
         }
 
+        if (this.state.isPointerOverGlobe) {
+            return;
+        }
+
         this.autoRotationResumeTimer = setTimeout(() => {
             this.autoRotationResumeTimer = null;
-            if (!this.state.isUserInteracting && this.options.autoRotate) {
+            if (!this.state.isUserInteracting && !this.state.isPointerOverGlobe && this.options.autoRotate) {
                 this.applyAutoRotationState(true);
             }
         }, this.getAutoRotationResumeDelay());


### PR DESCRIPTION
## Что изменено
- Добавлено состояние `isPointerOverGlobe`, которое удерживает автоповорот выключенным после взаимодействия, пока курсор остается над глобусом.
- Таймер возобновления запускается только после `pointerleave` или release вне области глобуса.
- Расширены регрессионные тесты для автоповорота.

## Как воспроизвести
1. Дождаться автоматического вращения глобуса.
2. Повернуть глобус мышью и отпустить кнопку, не уводя курсор с глобуса.
3. Автовращение не должно возобновляться, пока курсор остается над глобусом.

## Проверка
- `node --test experiments/community-globe-auto-rotation.test.mjs`
- `node --test experiments/*.test.mjs`
- Playwright browser check: while pointer is over the globe, no resume timer is created; after pointer leave, the 1200ms test delay resumes rotation.
- `dotnet build` не выполнен локально: установлен только .NET SDK 8.0.125, проект таргетит `net10.0` и падает с NETSDK1045.

Fixes MiheevN/ZealousGeoLibrary#23