### PR TITLE
Reduce globe camera rotate speed near surface

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-11T12:17:11.494Z for PR creation at branch issue-47-c6c563bf23d1 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/47

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-11T12:17:11.494Z for PR creation at branch issue-47-c6c563bf23d1 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/47

--- a/experiments/community-globe-camera.test.mjs
+++ b/experiments/community-globe-camera.test.mjs
@@ -44,6 +44,9 @@ function createGlobePrototypeInstance(CommunityGlobe, options = {}) {
         cameraZoomInMaxSpeed: 0.9,
         cameraZoomOutSpeed: 1.15,
         cameraZoomSlowdownDistance: 1.1,
+        cameraRotateMinSpeed: 0.18,
+        cameraRotateMaxSpeed: 1.0,
+        cameraRotateSlowdownDistance: 1.5,
         participantMarkerReferenceDistance: 2.6,
         participantMarkerMinScale: 0.35,
         participantMarkerMaxScale: 1.2,
@@ -100,6 +103,20 @@ test('zooming in slows near the surface while zooming out remains responsive', a
     assert.equal(nearInSpeed, 0.16);
     assert.equal(farInSpeed, 0.9);
     assert.equal(outSpeed, 1.15);
+});
+
+test('camera rotate sensitivity decreases as the camera approaches the surface', async () => {
+    const CommunityGlobe = await loadCommunityGlobeClass();
+    const globe = createGlobePrototypeInstance(CommunityGlobe);
+
+    const nearSpeed = globe.calculateCameraRotateSpeed(1.03);
+    const midSpeed = globe.calculateCameraRotateSpeed(1.78);
+    const farSpeed = globe.calculateCameraRotateSpeed(3.2);
+
+    assert.equal(nearSpeed, 0.18);
+    assert.equal(farSpeed, 1.0);
+    assert.ok(nearSpeed < midSpeed && midSpeed < farSpeed, 'rotate speed should grow with camera distance');
+    assert.ok(Math.abs(midSpeed - 0.59) < 0.01, 'rotate speed should be near the midpoint at the slowdown midpoint');
 });
 
 test('participant marker scale follows camera distance within configured bounds', async () => {

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -126,6 +126,9 @@ class CommunityGlobe {
             cameraZoomInMaxSpeed: 0.9,
             cameraZoomOutSpeed: 1.15,
             cameraZoomSlowdownDistance: 1.1,
+            cameraRotateMinSpeed: 0.18,
+            cameraRotateMaxSpeed: 1.0,
+            cameraRotateSlowdownDistance: 1.5,
             levelOfDetail: 2,
             earthTextureUrl: "/_content/ZealousMindedPeopleGeo/assets/earth/8k_earth_daymap.jpg",
             normalTextureUrl: "/_content/ZealousMindedPeopleGeo/assets/earth/8k_earth_normal_map.tif",
@@ -589,6 +592,7 @@ class CommunityGlobe {
         }
         this.updateCameraControlLimits();
         this.controls.zoomSpeed = this.calculateCameraZoomSpeed(this.camera.position.length(), false);
+        this.controls.rotateSpeed = this.calculateCameraRotateSpeed(this.camera.position.length());
         this.controls.autoRotate = this.state.isAutoRotating;
         this.controls.autoRotateSpeed = this.options.autoRotateSpeed;
         this.controls.addEventListener('start', () => this.pauseAutoRotationForInteraction());
@@ -1157,6 +1161,24 @@ class CommunityGlobe {
         this.controls.zoomSpeed = this.calculateCameraZoomSpeed(this.camera.position.length(), event.deltaY < 0);
     }
 
+    calculateCameraRotateSpeed(cameraDistance) {
+        const { minDistance } = this.getCameraDistanceLimits();
+        const minSpeed = this.getPositiveNumber(this.options.cameraRotateMinSpeed, 0.18);
+        const maxSpeed = Math.max(minSpeed, this.getPositiveNumber(this.options.cameraRotateMaxSpeed, 1.0));
+        const slowdownDistance = this.getPositiveNumber(this.options.cameraRotateSlowdownDistance, 1.5);
+        const progress = this.clamp((cameraDistance - minDistance) / slowdownDistance, 0, 1);
+
+        return minSpeed + (maxSpeed - minSpeed) * progress;
+    }
+
+    updateCameraRotateSpeed() {
+        if (!this.controls || !this.camera) {
+            return;
+        }
+
+        this.controls.rotateSpeed = this.calculateCameraRotateSpeed(this.camera.position.length());
+    }
+
     updateCameraControlLimits() {
         if (!this.controls) return;
 
@@ -1638,6 +1660,7 @@ class CommunityGlobe {
 
         if (this.controls) {
             this.updateCameraControlLimits();
+            this.updateCameraRotateSpeed();
             this.controls.update();
         }
         this.applyCameraDistanceSafety();
@@ -1996,6 +2019,9 @@ class CommunityGlobe {
                 'cameraZoomInMaxSpeed',
                 'cameraZoomOutSpeed',
                 'cameraZoomSlowdownDistance',
+                'cameraRotateMinSpeed',
+                'cameraRotateMaxSpeed',
+                'cameraRotateSlowdownDistance',
                 'sunLightFollowCamera',
                 'sunLightDistance',
                 'ambientLightColor',


### PR DESCRIPTION
## Summary

Closes #47.

When the camera was zoomed close to the planet, even small mouse movements rotated the view across a large slice of the visible surface, making interaction feel jumpy. This change makes the OrbitControls rotation speed scale with camera distance, mirroring the existing zoom-speed slowdown logic, so close-up movement is significantly smoother.

## Changes

- `wwwroot/js/community-globe.js`
  - New `calculateCameraRotateSpeed(cameraDistance)` interpolates between `cameraRotateMinSpeed` (close) and `cameraRotateMaxSpeed` (far) over `cameraRotateSlowdownDistance`.
  - `setupControls()` initializes `controls.rotateSpeed` based on the current camera distance.
  - `animate()` calls `updateCameraRotateSpeed()` each frame so dragging the globe while zoomed in stays slow without needing a wheel event.
  - New defaults are added: `cameraRotateMinSpeed: 0.18`, `cameraRotateMaxSpeed: 1.0`, `cameraRotateSlowdownDistance: 1.5`. They are also recognized by `updateSettings()` so they can be tuned through the settings UI.

- `experiments/community-globe-camera.test.mjs`
  - Adds defaults to the prototype-instance helper.
  - Adds a regression test verifying rotate speed equals the configured min at the closest distance, hits the configured max at far range, and grows monotonically across the slowdown band.

## Test plan

- [x] `node --test experiments/*.test.mjs` (34/34 pass, including new `camera rotate sensitivity decreases as the camera approaches the surface`).
- [x] Loaded `experiments/community-globe-lighting-preview.html` in a browser via local HTTP server, called `centerOn` to move the camera close to and far from the globe; the page renders without errors and the new rotate-speed code path runs each frame inside `animate()`.