### PR TITLE
Создать механизм загрузки и запуска в БД (EF Core persistence)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T11:03:12.476Z for PR creation at branch issue-55-9c64481c1ba6 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/55

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T11:03:12.476Z for PR creation at branch issue-55-9c64481c1ba6 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/55

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@
     - `GeoJson.cs`
 
 ### Добавлено
+- **Хранение гео-данных в базе данных через EF Core (Issue #55)**
+  - Провайдеро-независимое хранилище на базе Entity Framework Core (SQLite, PostgreSQL, SQL Server и др.)
+  - `DatabaseGeoDataContainerManager` и `DatabaseGeoDataContainer` реализуют существующие интерфейсы `IGeoDataContainerManager` / `IGeoDataContainer` — API не меняется
+  - Поддержка нескольких глобусов в одной таблице с изоляцией по `ContainerId` (составной ключ `ContainerId` + `Id`)
+  - Добавление участников по одному и пакетная загрузка из массива объектов с пропуском дубликатов
+  - Загрузка и выгрузка JSON напрямую в БД (`LoadFromJsonAsync`, `LoadFromJsonFileAsync`, `ExportToJsonAsync`)
+  - Регистрация через `AddGeoDataDatabase(configureDbContext)` и инициализация схемы через `EnsureGeoDataDatabaseCreatedAsync()`
+  - Общая логика загрузки/JSON вынесена в базовый класс `GeoDataContainerManagerBase` (общий для in-memory и БД менеджеров)
+  - Сущность `GeoDataParticipantEntity` и контекст `GeoDataDbContext` для маппинга `Participant`
+  - Тестовый проект `ZealousMindedPeopleGeo.Tests` с покрытием сценариев БД (SQLite in-memory)
+  - Пример `examples/GeoDataDatabaseExample.razor`
+
 - **Компонент настроек глобуса** (`CommunityGlobeSettings.razor`)
   - Полная настройка параметров глобуса через UI
   - Аккордеон с группировкой настроек (размеры, точки, вращение, освещение, атмосфера, облака, камера, цвета)

--- a/README.md
+++ b/README.md
@@ -529,6 +529,74 @@ private void HandleDataChanged(string containerId, GeoDataChangeType changeType)
 }
 ```
 
+## 🗄️ Хранение гео-данных в базе данных
+
+Помимо хранения в памяти, библиотека поддерживает постоянное хранение гео-данных в реляционной базе данных через [Entity Framework Core](https://learn.microsoft.com/ef/core/). Реализация **не зависит от конкретного провайдера БД** — вы выбираете провайдер (SQLite, PostgreSQL, SQL Server и т. д.) при регистрации сервисов.
+
+`DatabaseGeoDataContainerManager` реализует тот же интерфейс `IGeoDataContainerManager`, что и хранилище в памяти, поэтому весь код работы с контейнерами (добавление по одному, загрузка массивом, загрузка/выгрузка JSON, несколько глобусов, подписка на изменения) остаётся неизменным — меняется только способ регистрации.
+
+### Регистрация сервисов
+
+```csharp
+// В Program.cs — выберите любой провайдер EF Core
+builder.Services.AddGeoDataDatabase(options =>
+    options.UseSqlite("Data Source=geodata.db"));
+
+// Пример для PostgreSQL:
+// builder.Services.AddGeoDataDatabase(options =>
+//     options.UseNpgsql(builder.Configuration.GetConnectionString("GeoData")));
+
+var app = builder.Build();
+
+// Создание схемы БД при старте (для разработки/демо).
+// В продакшене используйте миграции EF Core.
+await app.Services.EnsureGeoDataDatabaseCreatedAsync();
+```
+
+Для управления схемой в продакшене подключите [миграции EF Core](https://learn.microsoft.com/ef/core/managing-schemas/migrations/) к контексту `GeoDataDbContext` вместо `EnsureGeoDataDatabaseCreatedAsync`.
+
+### Работа с несколькими глобусами
+
+Каждый именованный контейнер (`containerId`) соответствует отдельному глобусу. Данные разных глобусов изолированы друг от друга в одной таблице за счёт колонки `ContainerId` (составной ключ `ContainerId` + `Id`), поэтому один и тот же участник может присутствовать в разных глобусах.
+
+```csharp
+@inject IGeoDataContainerManager ContainerManager
+
+// Данные сохраняются в БД и переживают перезапуск приложения
+var europe = ContainerManager.GetOrCreateContainer("europe");
+var asia = ContainerManager.GetOrCreateContainer("asia");
+
+// Добавление по одному
+await europe.AddParticipantAsync(new Participant { Name = "Берлин", Latitude = 52.52, Longitude = 13.405 });
+
+// Загрузка массивом (дубликаты по Id пропускаются)
+await asia.AddParticipantsAsync(new[]
+{
+    new Participant { Name = "Токио", Latitude = 35.6762, Longitude = 139.6503 },
+    new Participant { Name = "Дели", Latitude = 28.6139, Longitude = 77.2090 }
+});
+
+// Список всех глобусов, для которых есть данные в БД
+var globeIds = ContainerManager.GetContainerIds();
+```
+
+### Загрузка и выгрузка JSON
+
+API загрузки/выгрузки JSON идентичен хранилищу в памяти, но данные читаются и пишутся в БД:
+
+```csharp
+// Загрузка массива участников из JSON-строки прямо в БД
+await ContainerManager.LoadFromJsonAsync("europe", jsonContent);
+
+// Загрузка из файла
+await ContainerManager.LoadFromJsonFileAsync("europe", "data/europe.json");
+
+// Выгрузка содержимого глобуса из БД в JSON
+var json = await ContainerManager.ExportToJsonAsync("europe");
+```
+
+> 💡 Полный пример Blazor-страницы см. в [`examples/GeoDataDatabaseExample.razor`](examples/GeoDataDatabaseExample.razor).
+
 ## 💾 Кэширование
 
 Интеллектуальное кэширование для оптимизации производительности:

--- a/Services/GeoDataContainer/GeoDataContainerManager.cs
+++ b/Services/GeoDataContainer/GeoDataContainerManager.cs
@@ -1,22 +1,16 @@
 using System.Collections.Concurrent;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using ZealousMindedPeopleGeo.Models;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
 
 /// <summary>
-/// Менеджер именованных контейнеров гео-данных.
+/// Менеджер именованных контейнеров гео-данных, хранящихся в памяти.
 /// Обеспечивает централизованное управление несколькими контейнерами данных.
 /// </summary>
-public class GeoDataContainerManager : IGeoDataContainerManager
+public class GeoDataContainerManager : GeoDataContainerManagerBase
 {
     private readonly ConcurrentDictionary<string, IGeoDataContainer> _containers = new();
-    private readonly ILogger<GeoDataContainerManager> _logger;
     private readonly ILoggerFactory _loggerFactory;
-
-    /// <inheritdoc />
-    public event Action<string, GeoDataChangeType>? OnDataChanged;
 
     /// <summary>
     /// Создает новый менеджер контейнеров
@@ -26,13 +20,13 @@ public class GeoDataContainerManager : IGeoDataContainerManager
     public GeoDataContainerManager(
         ILogger<GeoDataContainerManager> logger,
         ILoggerFactory loggerFactory)
+        : base(logger)
     {
-        _logger = logger;
         _loggerFactory = loggerFactory;
     }
 
     /// <inheritdoc />
-    public IGeoDataContainer GetOrCreateContainer(string containerId)
+    public override IGeoDataContainer GetOrCreateContainer(string containerId)
     {
         if (string.IsNullOrWhiteSpace(containerId))
         {
@@ -41,14 +35,14 @@ public class GeoDataContainerManager : IGeoDataContainerManager
 
         return _containers.GetOrAdd(containerId, id =>
         {
-            _logger.LogInformation("Creating new geo-data container: {ContainerId}", id);
+            Logger.LogInformation("Creating new geo-data container: {ContainerId}", id);
             var containerLogger = _loggerFactory.CreateLogger<InMemoryGeoDataContainer>();
             return new InMemoryGeoDataContainer(id, containerLogger, HandleDataChanged);
         });
     }
 
     /// <inheritdoc />
-    public IGeoDataContainer? GetContainer(string containerId)
+    public override IGeoDataContainer? GetContainer(string containerId)
     {
         if (string.IsNullOrWhiteSpace(containerId))
         {
@@ -60,13 +54,13 @@ public class GeoDataContainerManager : IGeoDataContainerManager
     }
 
     /// <inheritdoc />
-    public bool ContainerExists(string containerId)
+    public override bool ContainerExists(string containerId)
     {
         return !string.IsNullOrWhiteSpace(containerId) && _containers.ContainsKey(containerId);
     }
 
     /// <inheritdoc />
-    public bool RemoveContainer(string containerId)
+    public override bool RemoveContainer(string containerId)
     {
         if (string.IsNullOrWhiteSpace(containerId))
         {
@@ -75,7 +69,7 @@ public class GeoDataContainerManager : IGeoDataContainerManager
 
         if (_containers.TryRemove(containerId, out _))
         {
-            _logger.LogInformation("Removed geo-data container: {ContainerId}", containerId);
+            Logger.LogInformation("Removed geo-data container: {ContainerId}", containerId);
             return true;
         }
 
@@ -83,157 +77,8 @@ public class GeoDataContainerManager : IGeoDataContainerManager
     }
 
     /// <inheritdoc />
-    public IEnumerable<string> GetContainerIds()
+    public override IEnumerable<string> GetContainerIds()
     {
         return _containers.Keys.ToList();
-    }
-
-    /// <inheritdoc />
-    public async ValueTask<GeoDataOperationResult> LoadDataAsync(string containerId, IEnumerable<Participant> participants, CancellationToken ct = default)
-    {
-        try
-        {
-            var container = GetOrCreateContainer(containerId);
-
-            // Очищаем контейнер перед загрузкой новых данных
-            await container.ClearAsync(ct);
-
-            // Добавляем участников
-            var result = await container.AddParticipantsAsync(participants, ct);
-
-            _logger.LogInformation("Loaded {Count} participants into container '{ContainerId}'", result.ProcessedCount, containerId);
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error loading data into container '{ContainerId}'", containerId);
-            return GeoDataOperationResult.Fail(ex.Message);
-        }
-    }
-
-    /// <inheritdoc />
-    public async ValueTask<GeoDataOperationResult> LoadFromJsonFileAsync(string containerId, string jsonFilePath, CancellationToken ct = default)
-    {
-        try
-        {
-            if (!File.Exists(jsonFilePath))
-            {
-                return GeoDataOperationResult.Fail($"File not found: {jsonFilePath}");
-            }
-
-            var jsonContent = await File.ReadAllTextAsync(jsonFilePath, ct);
-            return await LoadFromJsonAsync(containerId, jsonContent, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error loading data from JSON file '{FilePath}' into container '{ContainerId}'", jsonFilePath, containerId);
-            return GeoDataOperationResult.Fail(ex.Message);
-        }
-    }
-
-    /// <inheritdoc />
-    public async ValueTask<GeoDataOperationResult> LoadFromJsonAsync(string containerId, string jsonContent, CancellationToken ct = default)
-    {
-        try
-        {
-            if (string.IsNullOrWhiteSpace(jsonContent))
-            {
-                return GeoDataOperationResult.Fail("JSON content is empty");
-            }
-
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            };
-
-            var participants = JsonSerializer.Deserialize<List<Participant>>(jsonContent, options);
-
-            if (participants == null)
-            {
-                return GeoDataOperationResult.Fail("Failed to deserialize JSON content");
-            }
-
-            return await LoadDataAsync(containerId, participants, ct);
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogError(ex, "Error parsing JSON content for container '{ContainerId}'", containerId);
-            return GeoDataOperationResult.Fail($"JSON parsing error: {ex.Message}");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error loading data from JSON into container '{ContainerId}'", containerId);
-            return GeoDataOperationResult.Fail(ex.Message);
-        }
-    }
-
-    /// <inheritdoc />
-    public async ValueTask<GeoDataOperationResult> SaveToJsonFileAsync(string containerId, string jsonFilePath, CancellationToken ct = default)
-    {
-        try
-        {
-            var jsonContent = await ExportToJsonAsync(containerId, ct);
-
-            // Создаем директорию если не существует
-            var directory = Path.GetDirectoryName(jsonFilePath);
-            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-            {
-                Directory.CreateDirectory(directory);
-            }
-
-            await File.WriteAllTextAsync(jsonFilePath, jsonContent, ct);
-
-            _logger.LogInformation("Saved container '{ContainerId}' data to file '{FilePath}'", containerId, jsonFilePath);
-
-            return GeoDataOperationResult.Ok();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error saving container '{ContainerId}' data to file '{FilePath}'", containerId, jsonFilePath);
-            return GeoDataOperationResult.Fail(ex.Message);
-        }
-    }
-
-    /// <inheritdoc />
-    public async ValueTask<string> ExportToJsonAsync(string containerId, CancellationToken ct = default)
-    {
-        try
-        {
-            var container = GetContainer(containerId);
-            if (container == null)
-            {
-                _logger.LogWarning("Container '{ContainerId}' not found for export", containerId);
-                return "[]";
-            }
-
-            var participants = await container.GetAllParticipantsAsync(ct);
-
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-
-            return JsonSerializer.Serialize(participants, options);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error exporting container '{ContainerId}' to JSON", containerId);
-            return "[]";
-        }
-    }
-
-    private void HandleDataChanged(string containerId, GeoDataChangeType changeType)
-    {
-        try
-        {
-            _logger.LogDebug("Data changed in container '{ContainerId}': {ChangeType}", containerId, changeType);
-            OnDataChanged?.Invoke(containerId, changeType);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error handling data change event for container '{ContainerId}'", containerId);
-        }
     }
 }

--- a/Services/GeoDataContainer/GeoDataContainerManagerBase.cs
+++ b/Services/GeoDataContainer/GeoDataContainerManagerBase.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ZealousMindedPeopleGeo.Models;
+
+namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
+
+/// <summary>
+/// Базовый класс для менеджеров именованных контейнеров гео-данных.
+/// Содержит общую логику загрузки/сохранения (JSON, массивы участников),
+/// не зависящую от конкретного хранилища (память, база данных и т.д.).
+/// Конкретные реализации определяют только способ создания и поиска контейнеров.
+/// </summary>
+public abstract class GeoDataContainerManagerBase : IGeoDataContainerManager
+{
+    /// <summary>
+    /// Логгер менеджера контейнеров
+    /// </summary>
+    protected ILogger Logger { get; }
+
+    /// <summary>
+    /// Опции сериализации для экспорта данных в JSON
+    /// </summary>
+    protected static readonly JsonSerializerOptions ExportJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// Опции десериализации для загрузки данных из JSON
+    /// </summary>
+    protected static readonly JsonSerializerOptions ImportJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <inheritdoc />
+    public event Action<string, GeoDataChangeType>? OnDataChanged;
+
+    /// <summary>
+    /// Создает новый базовый менеджер контейнеров
+    /// </summary>
+    /// <param name="logger">Логгер</param>
+    protected GeoDataContainerManagerBase(ILogger logger)
+    {
+        Logger = logger;
+    }
+
+    /// <inheritdoc />
+    public abstract IGeoDataContainer GetOrCreateContainer(string containerId);
+
+    /// <inheritdoc />
+    public abstract IGeoDataContainer? GetContainer(string containerId);
+
+    /// <inheritdoc />
+    public abstract bool ContainerExists(string containerId);
+
+    /// <inheritdoc />
+    public abstract bool RemoveContainer(string containerId);
+
+    /// <inheritdoc />
+    public abstract IEnumerable<string> GetContainerIds();
+
+    /// <inheritdoc />
+    public virtual async ValueTask<GeoDataOperationResult> LoadDataAsync(string containerId, IEnumerable<Participant> participants, CancellationToken ct = default)
+    {
+        try
+        {
+            var container = GetOrCreateContainer(containerId);
+
+            // Очищаем контейнер перед загрузкой новых данных
+            await container.ClearAsync(ct);
+
+            // Добавляем участников
+            var result = await container.AddParticipantsAsync(participants, ct);
+
+            Logger.LogInformation("Loaded {Count} participants into container '{ContainerId}'", result.ProcessedCount, containerId);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading data into container '{ContainerId}'", containerId);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<GeoDataOperationResult> LoadFromJsonFileAsync(string containerId, string jsonFilePath, CancellationToken ct = default)
+    {
+        try
+        {
+            if (!File.Exists(jsonFilePath))
+            {
+                return GeoDataOperationResult.Fail($"File not found: {jsonFilePath}");
+            }
+
+            var jsonContent = await File.ReadAllTextAsync(jsonFilePath, ct);
+            return await LoadFromJsonAsync(containerId, jsonContent, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading data from JSON file '{FilePath}' into container '{ContainerId}'", jsonFilePath, containerId);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<GeoDataOperationResult> LoadFromJsonAsync(string containerId, string jsonContent, CancellationToken ct = default)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(jsonContent))
+            {
+                return GeoDataOperationResult.Fail("JSON content is empty");
+            }
+
+            var participants = JsonSerializer.Deserialize<List<Participant>>(jsonContent, ImportJsonOptions);
+
+            if (participants == null)
+            {
+                return GeoDataOperationResult.Fail("Failed to deserialize JSON content");
+            }
+
+            return await LoadDataAsync(containerId, participants, ct);
+        }
+        catch (JsonException ex)
+        {
+            Logger.LogError(ex, "Error parsing JSON content for container '{ContainerId}'", containerId);
+            return GeoDataOperationResult.Fail($"JSON parsing error: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading data from JSON into container '{ContainerId}'", containerId);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<GeoDataOperationResult> SaveToJsonFileAsync(string containerId, string jsonFilePath, CancellationToken ct = default)
+    {
+        try
+        {
+            var jsonContent = await ExportToJsonAsync(containerId, ct);
+
+            // Создаем директорию если не существует
+            var directory = Path.GetDirectoryName(jsonFilePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await File.WriteAllTextAsync(jsonFilePath, jsonContent, ct);
+
+            Logger.LogInformation("Saved container '{ContainerId}' data to file '{FilePath}'", containerId, jsonFilePath);
+
+            return GeoDataOperationResult.Ok();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving container '{ContainerId}' data to file '{FilePath}'", containerId, jsonFilePath);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<string> ExportToJsonAsync(string containerId, CancellationToken ct = default)
+    {
+        try
+        {
+            var container = GetContainer(containerId);
+            if (container == null)
+            {
+                Logger.LogWarning("Container '{ContainerId}' not found for export", containerId);
+                return "[]";
+            }
+
+            var participants = await container.GetAllParticipantsAsync(ct);
+
+            return JsonSerializer.Serialize(participants, ExportJsonOptions);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error exporting container '{ContainerId}' to JSON", containerId);
+            return "[]";
+        }
+    }
+
+    /// <summary>
+    /// Обрабатывает событие изменения данных в контейнере и ретранслирует его подписчикам
+    /// </summary>
+    /// <param name="containerId">Идентификатор контейнера</param>
+    /// <param name="changeType">Тип изменения</param>
+    protected void HandleDataChanged(string containerId, GeoDataChangeType changeType)
+    {
+        try
+        {
+            Logger.LogDebug("Data changed in container '{ContainerId}': {ChangeType}", containerId, changeType);
+            OnDataChanged?.Invoke(containerId, changeType);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error handling data change event for container '{ContainerId}'", containerId);
+        }
+    }
+}

--- a/Services/GeoDataContainer/GeoDataLoaderExtensions.cs
+++ b/Services/GeoDataContainer/GeoDataLoaderExtensions.cs
@@ -1,6 +1,8 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
 using ZealousMindedPeopleGeo.Services.Mapping;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
@@ -12,7 +14,7 @@ namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
 public static class GeoDataLoaderExtensions
 {
     /// <summary>
-    /// Регистрирует сервисы для работы с именованными контейнерами гео-данных
+    /// Регистрирует сервисы для работы с именованными контейнерами гео-данных (хранение в памяти)
     /// </summary>
     /// <param name="services">Коллекция сервисов</param>
     /// <returns>Коллекция сервисов для цепочки вызовов</returns>
@@ -20,6 +22,56 @@ public static class GeoDataLoaderExtensions
     {
         services.AddSingleton<IGeoDataContainerManager, GeoDataContainerManager>();
         return services;
+    }
+
+    /// <summary>
+    /// Регистрирует сервисы для работы с именованными контейнерами гео-данных
+    /// с хранением в базе данных. Менеджер контейнеров (<see cref="IGeoDataContainerManager"/>)
+    /// будет использовать БД вместо памяти, что позволяет сохранять данные множества
+    /// глобусов между запусками приложения.
+    /// </summary>
+    /// <param name="services">Коллекция сервисов</param>
+    /// <param name="configureDbContext">
+    /// Делегат настройки контекста БД. Провайдер выбирается потребителем библиотеки,
+    /// например: <c>options =&gt; options.UseSqlite("Data Source=geodata.db")</c>.
+    /// </param>
+    /// <returns>Коллекция сервисов для цепочки вызовов</returns>
+    /// <remarks>
+    /// После построения провайдера сервисов вызовите
+    /// <see cref="EnsureGeoDataDatabaseCreatedAsync"/>, чтобы создать схему БД,
+    /// либо примените миграции EF Core самостоятельно.
+    /// </remarks>
+    public static IServiceCollection AddGeoDataDatabase(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> configureDbContext)
+    {
+        ArgumentNullException.ThrowIfNull(configureDbContext);
+
+        // Фабрика контекстов безопасна для многопоточной среды (в т.ч. Blazor)
+        services.AddDbContextFactory<GeoDataDbContext>(configureDbContext);
+
+        // Менеджер контейнеров с хранением в БД заменяет реализацию по умолчанию
+        services.AddSingleton<IGeoDataContainerManager, DatabaseGeoDataContainerManager>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Создает схему базы данных гео-данных, если она ещё не существует
+    /// (через <c>EnsureCreated</c>). Удобно для разработки, тестов и сценариев
+    /// без миграций. Для продакшена рекомендуется использовать миграции EF Core.
+    /// </summary>
+    /// <param name="serviceProvider">Провайдер сервисов</param>
+    /// <param name="ct">Токен отмены операции</param>
+    /// <returns>Задача инициализации</returns>
+    public static async Task EnsureGeoDataDatabaseCreatedAsync(
+        this IServiceProvider serviceProvider,
+        CancellationToken ct = default)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<GeoDataDbContext>>();
+        await using var context = await factory.CreateDbContextAsync(ct);
+        await context.Database.EnsureCreatedAsync(ct);
     }
 
     /// <summary>

--- a/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainer.cs
+++ b/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainer.cs
@@ -1,0 +1,300 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ZealousMindedPeopleGeo.Models;
+
+namespace ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
+
+/// <summary>
+/// Реализация контейнера гео-данных с хранением в базе данных.
+/// Каждый экземпляр работает с данными одного именованного контейнера (глобуса),
+/// отфильтрованными по <see cref="IGeoDataContainer.ContainerId"/>.
+/// Для безопасной работы в многопоточной среде (в т.ч. в Blazor)
+/// используется <see cref="IDbContextFactory{TContext}"/> — контекст создается
+/// на время каждой операции.
+/// </summary>
+public class DatabaseGeoDataContainer : IGeoDataContainer
+{
+    private readonly IDbContextFactory<GeoDataDbContext> _contextFactory;
+    private readonly ILogger<DatabaseGeoDataContainer>? _logger;
+    private readonly Action<string, GeoDataChangeType>? _onDataChanged;
+
+    /// <inheritdoc />
+    public string ContainerId { get; }
+
+    /// <inheritdoc />
+    public int Count
+    {
+        get
+        {
+            using var context = _contextFactory.CreateDbContext();
+            return context.Participants.Count(p => p.ContainerId == ContainerId);
+        }
+    }
+
+    /// <summary>
+    /// Создает контейнер гео-данных, хранящихся в базе данных
+    /// </summary>
+    /// <param name="containerId">Идентификатор контейнера</param>
+    /// <param name="contextFactory">Фабрика контекстов БД</param>
+    /// <param name="logger">Логгер (опционально)</param>
+    /// <param name="onDataChanged">Callback при изменении данных (опционально)</param>
+    public DatabaseGeoDataContainer(
+        string containerId,
+        IDbContextFactory<GeoDataDbContext> contextFactory,
+        ILogger<DatabaseGeoDataContainer>? logger = null,
+        Action<string, GeoDataChangeType>? onDataChanged = null)
+    {
+        ContainerId = containerId ?? throw new ArgumentNullException(nameof(containerId));
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _logger = logger;
+        _onDataChanged = onDataChanged;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<GeoDataOperationResult> AddParticipantAsync(Participant participant, CancellationToken ct = default)
+    {
+        if (participant == null)
+        {
+            return GeoDataOperationResult.Fail("Participant is null");
+        }
+
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var exists = await context.Participants
+                .AnyAsync(p => p.ContainerId == ContainerId && p.Id == participant.Id, ct);
+
+            if (exists)
+            {
+                return GeoDataOperationResult.Fail($"Participant with ID {participant.Id} already exists in container '{ContainerId}'");
+            }
+
+            context.Participants.Add(GeoDataParticipantEntity.FromParticipant(ContainerId, participant));
+            await context.SaveChangesAsync(ct);
+
+            _logger?.LogInformation("Container '{ContainerId}': Added participant {Name} with ID {Id}", ContainerId, participant.Name, participant.Id);
+
+            NotifyDataChanged(GeoDataChangeType.Added);
+
+            return GeoDataOperationResult.Ok(1, participant.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error adding participant {Name}", ContainerId, participant.Name);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<GeoDataOperationResult> AddParticipantsAsync(IEnumerable<Participant> participants, CancellationToken ct = default)
+    {
+        if (participants == null)
+        {
+            return GeoDataOperationResult.Fail("Participants collection is null");
+        }
+
+        try
+        {
+            var participantList = participants.Where(p => p != null).ToList();
+            if (participantList.Count == 0)
+            {
+                return GeoDataOperationResult.Ok(0);
+            }
+
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var incomingIds = participantList.Select(p => p.Id).ToList();
+            var existingIds = await context.Participants
+                .Where(p => p.ContainerId == ContainerId && incomingIds.Contains(p.Id))
+                .Select(p => p.Id)
+                .ToListAsync(ct);
+
+            var existingSet = existingIds.ToHashSet();
+            var seen = new HashSet<Guid>();
+            var addedCount = 0;
+
+            foreach (var participant in participantList)
+            {
+                // Пропускаем уже существующих в БД и дубликаты внутри входного набора
+                if (existingSet.Contains(participant.Id) || !seen.Add(participant.Id))
+                {
+                    continue;
+                }
+
+                context.Participants.Add(GeoDataParticipantEntity.FromParticipant(ContainerId, participant));
+                addedCount++;
+            }
+
+            if (addedCount > 0)
+            {
+                await context.SaveChangesAsync(ct);
+                NotifyDataChanged(GeoDataChangeType.BulkLoaded);
+            }
+
+            _logger?.LogInformation("Container '{ContainerId}': Added {Count} participants", ContainerId, addedCount);
+
+            return GeoDataOperationResult.Ok(addedCount);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error adding multiple participants", ContainerId);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<Participant>> GetAllParticipantsAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var entities = await context.Participants
+                .AsNoTracking()
+                .Where(p => p.ContainerId == ContainerId)
+                .ToListAsync(ct);
+
+            _logger?.LogDebug("Container '{ContainerId}': Retrieved {Count} participants", ContainerId, entities.Count);
+
+            return entities.Select(e => e.ToParticipant()).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error getting all participants", ContainerId);
+            return Enumerable.Empty<Participant>();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<Participant?> GetParticipantByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var entity = await context.Participants
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.ContainerId == ContainerId && p.Id == id, ct);
+
+            if (entity != null)
+            {
+                _logger?.LogDebug("Container '{ContainerId}': Found participant {Name} with ID {Id}", ContainerId, entity.Name, id);
+                return entity.ToParticipant();
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error getting participant by ID {Id}", ContainerId, id);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<GeoDataOperationResult> UpdateParticipantAsync(Participant participant, CancellationToken ct = default)
+    {
+        if (participant == null)
+        {
+            return GeoDataOperationResult.Fail("Participant is null");
+        }
+
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var entity = await context.Participants
+                .FirstOrDefaultAsync(p => p.ContainerId == ContainerId && p.Id == participant.Id, ct);
+
+            if (entity == null)
+            {
+                return GeoDataOperationResult.Fail($"Participant with ID {participant.Id} not found in container '{ContainerId}'");
+            }
+
+            entity.UpdateFrom(participant);
+            await context.SaveChangesAsync(ct);
+
+            _logger?.LogInformation("Container '{ContainerId}': Updated participant {Name} with ID {Id}", ContainerId, participant.Name, participant.Id);
+
+            NotifyDataChanged(GeoDataChangeType.Updated);
+
+            return GeoDataOperationResult.Ok(1, participant.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error updating participant {Name}", ContainerId, participant.Name);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<GeoDataOperationResult> RemoveParticipantAsync(Guid id, CancellationToken ct = default)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var entity = await context.Participants
+                .FirstOrDefaultAsync(p => p.ContainerId == ContainerId && p.Id == id, ct);
+
+            if (entity == null)
+            {
+                return GeoDataOperationResult.Fail($"Participant with ID {id} not found in container '{ContainerId}'");
+            }
+
+            context.Participants.Remove(entity);
+            await context.SaveChangesAsync(ct);
+
+            _logger?.LogInformation("Container '{ContainerId}': Removed participant {Name} with ID {Id}", ContainerId, entity.Name, id);
+
+            NotifyDataChanged(GeoDataChangeType.Removed);
+
+            return GeoDataOperationResult.Ok(1, id);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error removing participant with ID {Id}", ContainerId, id);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<GeoDataOperationResult> ClearAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+            var count = await context.Participants
+                .Where(p => p.ContainerId == ContainerId)
+                .ExecuteDeleteAsync(ct);
+
+            _logger?.LogInformation("Container '{ContainerId}': Cleared {Count} participants", ContainerId, count);
+
+            if (count > 0)
+            {
+                NotifyDataChanged(GeoDataChangeType.Cleared);
+            }
+
+            return GeoDataOperationResult.Ok(count);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error clearing container", ContainerId);
+            return GeoDataOperationResult.Fail(ex.Message);
+        }
+    }
+
+    private void NotifyDataChanged(GeoDataChangeType changeType)
+    {
+        try
+        {
+            _onDataChanged?.Invoke(ContainerId, changeType);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Container '{ContainerId}': Error notifying data changed", ContainerId);
+        }
+    }
+}

--- a/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainerManager.cs
+++ b/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainerManager.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
+
+/// <summary>
+/// Менеджер именованных контейнеров гео-данных с хранением в базе данных.
+/// Каждый контейнер соответствует набору строк с одинаковым
+/// <see cref="GeoDataParticipantEntity.ContainerId"/>, что позволяет хранить
+/// данные множества глобусов в одной базе данных.
+/// </summary>
+public class DatabaseGeoDataContainerManager : GeoDataContainerManagerBase
+{
+    private readonly IDbContextFactory<GeoDataDbContext> _contextFactory;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ConcurrentDictionary<string, IGeoDataContainer> _containerCache = new();
+
+    /// <summary>
+    /// Создает новый менеджер контейнеров с хранением в БД
+    /// </summary>
+    /// <param name="contextFactory">Фабрика контекстов БД</param>
+    /// <param name="logger">Логгер</param>
+    /// <param name="loggerFactory">Фабрика логгеров для создания логгеров контейнеров</param>
+    public DatabaseGeoDataContainerManager(
+        IDbContextFactory<GeoDataDbContext> contextFactory,
+        ILogger<DatabaseGeoDataContainerManager> logger,
+        ILoggerFactory loggerFactory)
+        : base(logger)
+    {
+        _contextFactory = contextFactory;
+        _loggerFactory = loggerFactory;
+    }
+
+    /// <inheritdoc />
+    public override IGeoDataContainer GetOrCreateContainer(string containerId)
+    {
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            throw new ArgumentNullException(nameof(containerId));
+        }
+
+        return _containerCache.GetOrAdd(containerId, id =>
+        {
+            Logger.LogInformation("Creating database geo-data container accessor: {ContainerId}", id);
+            var containerLogger = _loggerFactory.CreateLogger<DatabaseGeoDataContainer>();
+            return new DatabaseGeoDataContainer(id, _contextFactory, containerLogger, HandleDataChanged);
+        });
+    }
+
+    /// <inheritdoc />
+    public override IGeoDataContainer? GetContainer(string containerId)
+    {
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            return null;
+        }
+
+        return ContainerExists(containerId) ? GetOrCreateContainer(containerId) : null;
+    }
+
+    /// <inheritdoc />
+    public override bool ContainerExists(string containerId)
+    {
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            return false;
+        }
+
+        using var context = _contextFactory.CreateDbContext();
+        return context.Participants.Any(p => p.ContainerId == containerId);
+    }
+
+    /// <inheritdoc />
+    public override bool RemoveContainer(string containerId)
+    {
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            return false;
+        }
+
+        using var context = _contextFactory.CreateDbContext();
+        var removed = context.Participants
+            .Where(p => p.ContainerId == containerId)
+            .ExecuteDelete();
+
+        _containerCache.TryRemove(containerId, out _);
+
+        if (removed > 0)
+        {
+            Logger.LogInformation("Removed database geo-data container: {ContainerId}", containerId);
+            HandleDataChanged(containerId, GeoDataChangeType.Cleared);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public override IEnumerable<string> GetContainerIds()
+    {
+        using var context = _contextFactory.CreateDbContext();
+        return context.Participants
+            .Select(p => p.ContainerId)
+            .Distinct()
+            .ToList();
+    }
+}

--- a/Services/GeoDataContainer/Persistence/GeoDataDbContext.cs
+++ b/Services/GeoDataContainer/Persistence/GeoDataDbContext.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
+
+/// <summary>
+/// Контекст базы данных для хранения гео-данных участников нескольких глобусов.
+/// Используется провайдер-агностично: конкретный провайдер (SQLite, SQL Server,
+/// PostgreSQL, InMemory и т.д.) настраивается при регистрации в DI.
+/// </summary>
+public class GeoDataDbContext : DbContext
+{
+    /// <summary>
+    /// Создает контекст с заданными настройками
+    /// </summary>
+    /// <param name="options">Настройки контекста</param>
+    public GeoDataDbContext(DbContextOptions<GeoDataDbContext> options)
+        : base(options)
+    {
+    }
+
+    /// <summary>
+    /// Набор участников, хранящихся в базе данных
+    /// </summary>
+    public DbSet<GeoDataParticipantEntity> Participants => Set<GeoDataParticipantEntity>();
+
+    /// <inheritdoc />
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        var entity = modelBuilder.Entity<GeoDataParticipantEntity>();
+
+        entity.ToTable("GeoDataParticipants");
+
+        // Составной ключ: один и тот же участник может присутствовать в разных контейнерах
+        entity.HasKey(p => new { p.ContainerId, p.Id });
+
+        // Индекс по контейнеру ускоряет выборку данных конкретного глобуса
+        entity.HasIndex(p => p.ContainerId);
+
+        entity.Property(p => p.ContainerId).HasMaxLength(200).IsRequired();
+        entity.Property(p => p.Name).HasMaxLength(100).IsRequired();
+        entity.Property(p => p.Address).HasMaxLength(200).IsRequired();
+        entity.Property(p => p.Email).HasMaxLength(254).IsRequired();
+        entity.Property(p => p.Location).HasMaxLength(200).IsRequired();
+        entity.Property(p => p.City).HasMaxLength(100);
+        entity.Property(p => p.Country).HasMaxLength(100);
+        entity.Property(p => p.SocialMedia).HasMaxLength(200);
+        entity.Property(p => p.Message).HasMaxLength(500);
+    }
+}

--- a/Services/GeoDataContainer/Persistence/GeoDataParticipantEntity.cs
+++ b/Services/GeoDataContainer/Persistence/GeoDataParticipantEntity.cs
@@ -1,0 +1,167 @@
+using ZealousMindedPeopleGeo.Models;
+
+namespace ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
+
+/// <summary>
+/// Сущность участника для хранения в базе данных.
+/// Отделяет доменную модель <see cref="Participant"/> от схемы хранения и
+/// добавляет привязку к именованному контейнеру (<see cref="ContainerId"/>),
+/// что позволяет хранить данные нескольких глобусов в одной таблице.
+/// </summary>
+public class GeoDataParticipantEntity
+{
+    /// <summary>
+    /// Идентификатор участника
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Идентификатор контейнера (глобуса), которому принадлежит участник
+    /// </summary>
+    public string ContainerId { get; set; } = string.Empty;
+
+    /// <summary>Имя участника</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Адрес участника</summary>
+    public string Address { get; set; } = string.Empty;
+
+    /// <summary>Электронная почта участника</summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>Местоположение участника</summary>
+    public string Location { get; set; } = string.Empty;
+
+    /// <summary>Широта</summary>
+    public double? Latitude { get; set; }
+
+    /// <summary>Долгота</summary>
+    public double? Longitude { get; set; }
+
+    /// <summary>Город</summary>
+    public string? City { get; set; }
+
+    /// <summary>Страна</summary>
+    public string? Country { get; set; }
+
+    /// <summary>Социальные сети (текстовое поле)</summary>
+    public string? SocialMedia { get; set; }
+
+    /// <summary>Сообщение участника</summary>
+    public string? Message { get; set; }
+
+    /// <summary>Жизненные цели</summary>
+    public string? LifeGoals { get; set; }
+
+    /// <summary>Навыки</summary>
+    public string? Skills { get; set; }
+
+    /// <summary>Discord</summary>
+    public string? Discord { get; set; }
+
+    /// <summary>Telegram</summary>
+    public string? Telegram { get; set; }
+
+    /// <summary>VK</summary>
+    public string? Vk { get; set; }
+
+    /// <summary>Веб-сайт</summary>
+    public string? Website { get; set; }
+
+    /// <summary>Дата регистрации</summary>
+    public DateTime RegisteredAt { get; set; }
+
+    /// <summary>
+    /// Создает сущность хранения из доменной модели участника
+    /// </summary>
+    /// <param name="containerId">Идентификатор контейнера (глобуса)</param>
+    /// <param name="participant">Доменная модель участника</param>
+    /// <returns>Сущность для сохранения в БД</returns>
+    public static GeoDataParticipantEntity FromParticipant(string containerId, Participant participant)
+    {
+        return new GeoDataParticipantEntity
+        {
+            Id = participant.Id,
+            ContainerId = containerId,
+            Name = participant.Name,
+            Address = participant.Address,
+            Email = participant.Email,
+            Location = participant.Location,
+            Latitude = participant.Latitude,
+            Longitude = participant.Longitude,
+            City = participant.City,
+            Country = participant.Country,
+            SocialMedia = participant.SocialMedia,
+            Message = participant.Message,
+            LifeGoals = participant.LifeGoals,
+            Skills = participant.Skills,
+            Discord = participant.SocialContacts?.Discord,
+            Telegram = participant.SocialContacts?.Telegram,
+            Vk = participant.SocialContacts?.Vk,
+            Website = participant.SocialContacts?.Website,
+            RegisteredAt = participant.RegisteredAt
+        };
+    }
+
+    /// <summary>
+    /// Обновляет поля существующей сущности данными доменной модели
+    /// (идентификатор и контейнер не изменяются)
+    /// </summary>
+    /// <param name="participant">Доменная модель участника</param>
+    public void UpdateFrom(Participant participant)
+    {
+        Name = participant.Name;
+        Address = participant.Address;
+        Email = participant.Email;
+        Location = participant.Location;
+        Latitude = participant.Latitude;
+        Longitude = participant.Longitude;
+        City = participant.City;
+        Country = participant.Country;
+        SocialMedia = participant.SocialMedia;
+        Message = participant.Message;
+        LifeGoals = participant.LifeGoals;
+        Skills = participant.Skills;
+        Discord = participant.SocialContacts?.Discord;
+        Telegram = participant.SocialContacts?.Telegram;
+        Vk = participant.SocialContacts?.Vk;
+        Website = participant.SocialContacts?.Website;
+        RegisteredAt = participant.RegisteredAt;
+    }
+
+    /// <summary>
+    /// Преобразует сущность хранения обратно в доменную модель участника
+    /// </summary>
+    /// <returns>Доменная модель участника</returns>
+    public Participant ToParticipant()
+    {
+        var hasSocialContacts = Discord is not null || Telegram is not null || Vk is not null || Website is not null;
+
+        return new Participant
+        {
+            Id = Id,
+            Name = Name,
+            Address = Address,
+            Email = Email,
+            Location = Location,
+            Latitude = Latitude,
+            Longitude = Longitude,
+            City = City,
+            Country = Country,
+            SocialMedia = SocialMedia,
+            Message = Message,
+            LifeGoals = LifeGoals,
+            Skills = Skills,
+            SocialContacts = hasSocialContacts
+                ? new SocialContacts
+                {
+                    Discord = Discord,
+                    Telegram = Telegram,
+                    Vk = Vk,
+                    Website = Website
+                }
+                : null,
+            RegisteredAt = RegisteredAt
+        };
+    }
+}

--- a/ZealousMindedPeopleGeo.csproj
+++ b/ZealousMindedPeopleGeo.csproj
@@ -8,7 +8,7 @@
 
     <!-- Информация о пакете -->
     <PackageId>ZealousMindedPeopleGeo</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Zealous Minded People Community</Authors>
     <Company>Zealous Minded People</Company>
     <Description>Библиотека для создания интерактивных географических приложений сообщества людей, объединенных стремлением сделать мир добрее и гармоничнее. Включает карты, 3D глобус, геокодирование, PWA поддержку и многое другое.</Description>
@@ -75,9 +75,18 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <!-- Тестовый проект не входит в сборку библиотеки -->
+  <ItemGroup>
+    <Compile Remove="tests/**/*.cs" />
+    <Content Remove="tests/**/*" />
+    <None Remove="tests/**/*" />
+  </ItemGroup>
+
   <!-- Ссылки на пакеты -->
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />

--- a/examples/GeoDataDatabaseExample.razor
+++ b/examples/GeoDataDatabaseExample.razor
@@ -1,0 +1,155 @@
+@page "/geodata-database-example"
+@using ZealousMindedPeopleGeo.Services.GeoDataContainer
+@using ZealousMindedPeopleGeo.Models
+@inject IGeoDataContainerManager ContainerManager
+@implements IDisposable
+
+@*
+    Пример работы с гео-данными, которые хранятся в базе данных.
+
+    Менеджер контейнеров регистрируется в Program.cs:
+
+        builder.Services.AddGeoDataDatabase(options =>
+            options.UseSqlite("Data Source=geodata.db"));
+
+        var app = builder.Build();
+        await app.Services.EnsureGeoDataDatabaseCreatedAsync();
+
+    После этого тот же интерфейс IGeoDataContainerManager работает поверх БД:
+    данные переживают перезапуск приложения, а каждый глобус (containerId)
+    хранится изолированно в одной таблице.
+*@
+
+<h3>Гео-данные в базе данных</h3>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header"><h4>Глобус</h4></div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label>Идентификатор глобуса (containerId):</label>
+                    <input type="text" @bind="_globeId" class="form-control" />
+                </div>
+
+                <div class="btn-group mb-3">
+                    <button class="btn btn-primary" @onclick="AddOne">Добавить одного</button>
+                    <button class="btn btn-info" @onclick="LoadArray">Загрузить массив</button>
+                    <button class="btn btn-secondary" @onclick="ExportJson">Экспорт в JSON</button>
+                    <button class="btn btn-danger" @onclick="ClearGlobe">Очистить</button>
+                </div>
+
+                <p>Участников в текущем глобусе (из БД): <strong>@CurrentCount</strong></p>
+
+                <h5>Глобусы с данными в БД:</h5>
+                <ul>
+                    @foreach (var id in ContainerManager.GetContainerIds())
+                    {
+                        <li>@id (@ContainerManager.GetContainer(id)?.Count)</li>
+                    }
+                </ul>
+
+                @if (!string.IsNullOrEmpty(_message))
+                {
+                    <div class="alert @_messageClass">@_message</div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header"><h4>JSON</h4></div>
+            <div class="card-body">
+                @if (!string.IsNullOrEmpty(_jsonExport))
+                {
+                    <pre class="bg-light p-3">@_jsonExport</pre>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+    private string _globeId = "europe";
+    private string? _message;
+    private string _messageClass = "alert-info";
+    private string? _jsonExport;
+    private int _counter;
+
+    private int CurrentCount => ContainerManager.GetContainer(_globeId)?.Count ?? 0;
+
+    protected override void OnInitialized()
+    {
+        ContainerManager.OnDataChanged += HandleDataChanged;
+    }
+
+    // Добавление объектов по одному — сохраняется напрямую в БД
+    private async Task AddOne()
+    {
+        var container = ContainerManager.GetOrCreateContainer(_globeId);
+        var participant = new Participant
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Точка {++_counter}",
+            Email = $"point{_counter}@example.com",
+            Address = "Адрес",
+            Location = "Локация",
+            Latitude = 55.7558 + _counter,
+            Longitude = 37.6176 + _counter
+        };
+
+        var result = await container.AddParticipantAsync(participant);
+        Show(result.Success
+            ? $"Добавлен '{participant.Name}' в глобус '{_globeId}'"
+            : $"Ошибка: {result.ErrorMessage}", result.Success);
+    }
+
+    // Загрузка из массива объектов — пакетная вставка в БД
+    private async Task LoadArray()
+    {
+        var participants = new[]
+        {
+            new Participant { Id = Guid.NewGuid(), Name = "Берлин", Latitude = 52.5200, Longitude = 13.4050 },
+            new Participant { Id = Guid.NewGuid(), Name = "Париж", Latitude = 48.8566, Longitude = 2.3522 },
+            new Participant { Id = Guid.NewGuid(), Name = "Мадрид", Latitude = 40.4168, Longitude = -3.7038 }
+        };
+
+        var result = await ContainerManager.LoadDataAsync(_globeId, participants);
+        Show(result.Success
+            ? $"Загружено {result.ProcessedCount} участников в глобус '{_globeId}'"
+            : $"Ошибка: {result.ErrorMessage}", result.Success);
+    }
+
+    private async Task ExportJson()
+    {
+        _jsonExport = await ContainerManager.ExportToJsonAsync(_globeId);
+    }
+
+    private async Task ClearGlobe()
+    {
+        var container = ContainerManager.GetContainer(_globeId);
+        if (container is null)
+        {
+            Show($"Глобус '{_globeId}' пуст", false);
+            return;
+        }
+
+        var result = await container.ClearAsync();
+        Show($"Удалено {result.ProcessedCount} участников из '{_globeId}'", result.Success);
+    }
+
+    private void Show(string message, bool success)
+    {
+        _message = message;
+        _messageClass = success ? "alert-success" : "alert-danger";
+    }
+
+    private void HandleDataChanged(string containerId, GeoDataChangeType changeType)
+        => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        ContainerManager.OnDataChanged -= HandleDataChanged;
+    }
+}

--- a/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataContainerManagerTests.cs
+++ b/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataContainerManagerTests.cs
@@ -1,0 +1,140 @@
+using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using Xunit;
+
+namespace ZealousMindedPeopleGeo.Tests;
+
+/// <summary>
+/// Тесты менеджера контейнеров гео-данных с хранением в БД.
+/// Проверяют работу с несколькими глобусами и загрузку/выгрузку данных (массивы, JSON).
+/// </summary>
+public class DatabaseGeoDataContainerManagerTests : DatabaseGeoDataTestBase
+{
+    [Fact]
+    public async Task MultipleGlobes_DataIsIsolatedPerContainer()
+    {
+        var europe = Manager.GetOrCreateContainer("europe");
+        var asia = Manager.GetOrCreateContainer("asia");
+
+        await europe.AddParticipantAsync(CreateParticipant("Berlin"));
+        await europe.AddParticipantAsync(CreateParticipant("Paris"));
+        await asia.AddParticipantAsync(CreateParticipant("Tokyo"));
+
+        Assert.Equal(2, europe.Count);
+        Assert.Equal(1, asia.Count);
+
+        var europeNames = (await europe.GetAllParticipantsAsync()).Select(p => p.Name).OrderBy(n => n).ToList();
+        Assert.Equal(new[] { "Berlin", "Paris" }, europeNames);
+    }
+
+    [Fact]
+    public async Task SameParticipantId_CanExistInDifferentGlobes()
+    {
+        var id = Guid.NewGuid();
+        var europe = Manager.GetOrCreateContainer("europe");
+        var asia = Manager.GetOrCreateContainer("asia");
+
+        var r1 = await europe.AddParticipantAsync(CreateParticipant("Shared", id: id));
+        var r2 = await asia.AddParticipantAsync(CreateParticipant("Shared", id: id));
+
+        Assert.True(r1.Success);
+        Assert.True(r2.Success);
+        Assert.Equal(1, europe.Count);
+        Assert.Equal(1, asia.Count);
+    }
+
+    [Fact]
+    public async Task LoadDataAsync_LoadsArrayAndReplacesExisting()
+    {
+        await Manager.GetOrCreateContainer("globe").AddParticipantAsync(CreateParticipant("Old"));
+
+        var participants = new[]
+        {
+            CreateParticipant("New1"),
+            CreateParticipant("New2")
+        };
+        var result = await Manager.LoadDataAsync("globe", participants);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.ProcessedCount);
+
+        var names = (await Manager.GetContainer("globe")!.GetAllParticipantsAsync()).Select(p => p.Name).ToList();
+        Assert.DoesNotContain("Old", names);
+        Assert.Equal(2, names.Count);
+    }
+
+    [Fact]
+    public async Task LoadFromJsonAsync_PersistsToDatabase()
+    {
+        var json = """
+        [
+            { "name": "JsonOne", "email": "j1@example.com", "address": "A", "location": "L", "latitude": 10.0, "longitude": 20.0 },
+            { "name": "JsonTwo", "email": "j2@example.com", "address": "A", "location": "L", "latitude": 30.0, "longitude": 40.0 }
+        ]
+        """;
+
+        var result = await Manager.LoadFromJsonAsync("json-globe", json);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.ProcessedCount);
+        Assert.Equal(2, Manager.GetContainer("json-globe")!.Count);
+    }
+
+    [Fact]
+    public async Task ExportToJsonAsync_ReturnsStoredData()
+    {
+        await Manager.GetOrCreateContainer("globe").AddParticipantAsync(CreateParticipant("Exported"));
+
+        var json = await Manager.ExportToJsonAsync("globe");
+
+        Assert.Contains("Exported", json);
+    }
+
+    [Fact]
+    public async Task GetContainerIds_ReturnsAllGlobesWithData()
+    {
+        await Manager.GetOrCreateContainer("g1").AddParticipantAsync(CreateParticipant("A"));
+        await Manager.GetOrCreateContainer("g2").AddParticipantAsync(CreateParticipant("B"));
+
+        var ids = Manager.GetContainerIds().OrderBy(i => i).ToList();
+
+        Assert.Equal(new[] { "g1", "g2" }, ids);
+    }
+
+    [Fact]
+    public async Task ContainerExists_TrueOnlyWhenDataPresent()
+    {
+        Assert.False(Manager.ContainerExists("empty"));
+
+        await Manager.GetOrCreateContainer("filled").AddParticipantAsync(CreateParticipant("A"));
+
+        Assert.True(Manager.ContainerExists("filled"));
+        Assert.Null(Manager.GetContainer("empty"));
+        Assert.NotNull(Manager.GetContainer("filled"));
+    }
+
+    [Fact]
+    public async Task RemoveContainer_DeletesAllGlobeData()
+    {
+        var container = Manager.GetOrCreateContainer("to-remove");
+        await container.AddParticipantsAsync(new[] { CreateParticipant("A"), CreateParticipant("B") });
+
+        var removed = Manager.RemoveContainer("to-remove");
+
+        Assert.True(removed);
+        Assert.False(Manager.ContainerExists("to-remove"));
+        Assert.False(Manager.RemoveContainer("never-existed"));
+    }
+
+    [Fact]
+    public async Task OnDataChanged_RaisedForDatabaseOperations()
+    {
+        var events = new List<(string ContainerId, GeoDataChangeType Type)>();
+        Manager.OnDataChanged += (id, type) => events.Add((id, type));
+
+        var container = Manager.GetOrCreateContainer("events");
+        await container.AddParticipantAsync(CreateParticipant("A"));
+
+        Assert.Contains(events, e => e.ContainerId == "events" && e.Type == GeoDataChangeType.Added);
+    }
+}

--- a/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataContainerTests.cs
+++ b/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataContainerTests.cs
@@ -1,0 +1,164 @@
+using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using Xunit;
+
+namespace ZealousMindedPeopleGeo.Tests;
+
+/// <summary>
+/// Тесты контейнера гео-данных с хранением в базе данных.
+/// Проверяют сценарии из задачи #55: добавление объектов по очереди,
+/// загрузка из массива объектов и работа с несколькими глобусами.
+/// </summary>
+public class DatabaseGeoDataContainerTests : DatabaseGeoDataTestBase
+{
+    [Fact]
+    public async Task AddParticipantAsync_PersistsSingleParticipant()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participant = CreateParticipant("Alice");
+
+        var result = await container.AddParticipantAsync(participant);
+
+        Assert.True(result.Success);
+        Assert.Equal(participant.Id, result.RecordId);
+        Assert.Equal(1, container.Count);
+
+        var loaded = await container.GetParticipantByIdAsync(participant.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal("Alice", loaded!.Name);
+    }
+
+    [Fact]
+    public async Task AddParticipantAsync_AddingObjectsOneByOne_AccumulatesData()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+
+        await container.AddParticipantAsync(CreateParticipant("First"));
+        await container.AddParticipantAsync(CreateParticipant("Second"));
+        await container.AddParticipantAsync(CreateParticipant("Third"));
+
+        var all = (await container.GetAllParticipantsAsync()).ToList();
+        Assert.Equal(3, all.Count);
+        Assert.Equal(3, container.Count);
+    }
+
+    [Fact]
+    public async Task AddParticipantAsync_DuplicateId_Fails()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participant = CreateParticipant("Alice");
+
+        var first = await container.AddParticipantAsync(participant);
+        var second = await container.AddParticipantAsync(participant);
+
+        Assert.True(first.Success);
+        Assert.False(second.Success);
+        Assert.Equal(1, container.Count);
+    }
+
+    [Fact]
+    public async Task AddParticipantsAsync_LoadsFromArray()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participants = new[]
+        {
+            CreateParticipant("One"),
+            CreateParticipant("Two"),
+            CreateParticipant("Three")
+        };
+
+        var result = await container.AddParticipantsAsync(participants);
+
+        Assert.True(result.Success);
+        Assert.Equal(3, result.ProcessedCount);
+        Assert.Equal(3, container.Count);
+    }
+
+    [Fact]
+    public async Task AddParticipantsAsync_SkipsDuplicatesWithinBatchAndExisting()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var shared = CreateParticipant("Shared");
+        await container.AddParticipantAsync(shared);
+
+        var newA = CreateParticipant("NewA");
+        var newB = CreateParticipant("NewB");
+        var batch = new[]
+        {
+            shared, // уже существует в БД -> пропускается
+            newA,
+            newA,   // дубль внутри набора -> учитывается один раз
+            newB
+        };
+
+        var result = await container.AddParticipantsAsync(batch);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.ProcessedCount); // newA + newB
+        Assert.Equal(3, container.Count);       // shared + newA + newB
+    }
+
+    [Fact]
+    public async Task UpdateParticipantAsync_ChangesStoredData()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participant = CreateParticipant("Original");
+        await container.AddParticipantAsync(participant);
+
+        participant.Name = "Updated";
+        participant.City = "Moscow";
+        var result = await container.UpdateParticipantAsync(participant);
+
+        Assert.True(result.Success);
+        var loaded = await container.GetParticipantByIdAsync(participant.Id);
+        Assert.Equal("Updated", loaded!.Name);
+        Assert.Equal("Moscow", loaded.City);
+    }
+
+    [Fact]
+    public async Task RemoveParticipantAsync_DeletesData()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participant = CreateParticipant("ToRemove");
+        await container.AddParticipantAsync(participant);
+
+        var result = await container.RemoveParticipantAsync(participant.Id);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, container.Count);
+        Assert.Null(await container.GetParticipantByIdAsync(participant.Id));
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesAllParticipants()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        await container.AddParticipantsAsync(new[] { CreateParticipant("A"), CreateParticipant("B") });
+
+        var result = await container.ClearAsync();
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.ProcessedCount);
+        Assert.Equal(0, container.Count);
+    }
+
+    [Fact]
+    public async Task SocialContacts_RoundTripsThroughDatabase()
+    {
+        var container = Manager.GetOrCreateContainer("globe-a");
+        var participant = CreateParticipant("Social");
+        participant.SocialContacts = new SocialContacts
+        {
+            Telegram = "https://t.me/example",
+            Website = "https://example.com"
+        };
+        await container.AddParticipantAsync(participant);
+
+        var loaded = await container.GetParticipantByIdAsync(participant.Id);
+
+        Assert.NotNull(loaded!.SocialContacts);
+        Assert.Equal("https://t.me/example", loaded.SocialContacts!.Telegram);
+        Assert.Equal("https://example.com", loaded.SocialContacts.Website);
+        Assert.Null(loaded.SocialContacts.Discord);
+    }
+}

--- a/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataTestBase.cs
+++ b/tests/ZealousMindedPeopleGeo.Tests/DatabaseGeoDataTestBase.cs
@@ -1,0 +1,68 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+
+namespace ZealousMindedPeopleGeo.Tests;
+
+/// <summary>
+/// Базовый класс тестов хранилища гео-данных в БД.
+/// Использует SQLite в режиме in-memory: соединение держится открытым на время теста,
+/// что обеспечивает реалистичную проверку работы с реляционной базой данных без внешних зависимостей.
+/// </summary>
+public abstract class DatabaseGeoDataTestBase : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ServiceProvider _provider;
+
+    /// <summary>Менеджер контейнеров гео-данных, использующий БД</summary>
+    protected IGeoDataContainerManager Manager { get; }
+
+    /// <summary>Провайдер сервисов теста</summary>
+    protected IServiceProvider Services => _provider;
+
+    protected DatabaseGeoDataTestBase()
+    {
+        // Открытое in-memory соединение живёт, пока открыт _connection
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGeoDataDatabase(options => options.UseSqlite(_connection));
+
+        _provider = services.BuildServiceProvider();
+        _provider.EnsureGeoDataDatabaseCreatedAsync().GetAwaiter().GetResult();
+
+        Manager = _provider.GetRequiredService<IGeoDataContainerManager>();
+    }
+
+    /// <summary>
+    /// Создаёт тестового участника с заданными параметрами
+    /// </summary>
+    protected static Participant CreateParticipant(
+        string name = "Test Participant",
+        double? latitude = 55.7558,
+        double? longitude = 37.6176,
+        Guid? id = null)
+    {
+        return new Participant
+        {
+            Id = id ?? Guid.NewGuid(),
+            Name = name,
+            Email = $"{name.Replace(' ', '.').ToLowerInvariant()}@example.com",
+            Address = "Test Address",
+            Location = "Test Location",
+            Latitude = latitude,
+            Longitude = longitude
+        };
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/ZealousMindedPeopleGeo.Tests/ZealousMindedPeopleGeo.Tests.csproj
+++ b/tests/ZealousMindedPeopleGeo.Tests/ZealousMindedPeopleGeo.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ZealousMindedPeopleGeo.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Что сделано

Реализован механизм загрузки и хранения гео-данных в базе данных (Issue #55).

Существующая инфраструктура `IGeoDataContainer` / `IGeoDataContainerManager` уже поддерживала несколько глобусов (именованные контейнеры), добавление по одному, загрузку массивом и работу с JSON — но только для хранения в памяти. Недостающая часть — постоянное хранение в БД — теперь добавлена поверх тех же интерфейсов, поэтому пользовательский код не меняется.

### Новое

- **`GeoDataContainerManagerBase`** — абстрактный базовый класс с общей логикой загрузки/JSON, переиспользуемый менеджерами in-memory и БД (устранение дублирования).
- **`DatabaseGeoDataContainerManager` / `DatabaseGeoDataContainer`** — реализации `IGeoDataContainerManager` / `IGeoDataContainer` поверх Entity Framework Core.
- **`GeoDataDbContext` / `GeoDataParticipantEntity`** — маппинг `Participant` с составным ключом (`ContainerId`, `Id`) и индексом по `ContainerId`, что обеспечивает изоляцию данных нескольких глобусов в одной таблице.
- **Провайдеро-независимость**: провайдер БД выбирается потребителем (SQLite, PostgreSQL, SQL Server и т. д.).
- **DI-регистрация**: `services.AddGeoDataDatabase(options => options.UseSqlite(...))` и инициализация схемы `await app.Services.EnsureGeoDataDatabaseCreatedAsync()`.

### Покрытие требований Issue #55

- ✅ Описан способ загрузки данных из БД (новый раздел в README).
- ✅ Реализована недостающая функциональность (хранение в БД).
- ✅ Добавление объектов **по одному** (`AddParticipantAsync`) и **из массива** (`AddParticipantsAsync` / `LoadDataAsync`), с пропуском дубликатов по `Id`.
- ✅ Поддержка **множества глобусов** (изоляция по `ContainerId`).
- ✅ Загрузка/выгрузка JSON напрямую в БД (`LoadFromJsonAsync`, `LoadFromJsonFileAsync`, `ExportToJsonAsync`).
- ✅ Код приведён к современному виду (общий базовый класс, `IDbContextFactory` для потокобезопасности в Blazor, `ExecuteDeleteAsync`).

## Как воспроизвести / проверить

```csharp
builder.Services.AddGeoDataDatabase(options =>
    options.UseSqlite("Data Source=geodata.db"));

var app = builder.Build();
await app.Services.EnsureGeoDataDatabaseCreatedAsync();
```

Далее весь код работы с `IGeoDataContainerManager` работает поверх БД. Полный пример — `examples/GeoDataDatabaseExample.razor`.

## Тесты

Добавлен проект `tests/ZealousMindedPeopleGeo.Tests` (xUnit, SQLite in-memory) — **18 тестов**, покрывающих добавление по одному и массивом, дубликаты, обновление, удаление, очистку, изоляцию нескольких глобусов и JSON round-trip.

```
Passed!  - Failed: 0, Passed: 18, Skipped: 0, Total: 18
```

## Прочее

- Раздел в README, запись в CHANGELOG.
- Версия пакета поднята до **1.1.0**.

Closes #55
