### PR TITLE
Синхронизация изменений между пользователями

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-06T17:10:08.002Z for PR creation at branch issue-57-57598e033bc5 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/57

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-06T17:10:08.002Z for PR creation at branch issue-57-57598e033bc5 for issue https://github.com/MiheevN/ZealousGeoLibrary/issues/57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
     - `GeoJson.cs`
 
 ### Добавлено
+- **Синхронизация изменений между пользователями без постоянного опроса (Issue #57)**
+  - Добавлен общий уведомитель `IGeoDataChangeNotifier` для публикации изменений гео-данных внутри Blazor-приложения
+  - `GeoDataContainerManager` и `DatabaseGeoDataContainerManager` публикуют изменения контейнеров через общий уведомитель
+  - Встроенные репозитории участников публикуют добавление, обновление и удаление участников
+  - `CommunityGlobeViewer` автоматически перезагружает точки при изменении своего контейнера или общего репозитория
+  - `CommunityMapComponent` автоматически обновляет маркеры при изменениях общего репозитория
+  - Тестовая регистрация `InMemoryParticipantRepository` переведена на singleton, чтобы данные были общими для активных пользователей
+
 - **Хранение гео-данных в базе данных через EF Core (Issue #55)**
   - Провайдеро-независимое хранилище на базе Entity Framework Core (SQLite, PostgreSQL, SQL Server и др.)
   - `DatabaseGeoDataContainerManager` и `DatabaseGeoDataContainer` реализуют существующие интерфейсы `IGeoDataContainerManager` / `IGeoDataContainer` — API не меняется
@@ -49,6 +57,10 @@
   - Экспорт функции для вызова из Blazor
 
 ### Исправлено
+- **Одиночное добавление участника на 3D-глобус**
+  - `GlobeMediatorService.AddParticipantAsync` теперь добавляет одну точку без замены уже отображенных маркеров
+  - Форма и helper-сервис контейнеров обновляют глобус полным актуальным набором данных после сохранения
+
 - **Ошибка "Cannot read properties of null (reading 'removeChild')"**
   - Добавлена проверка `contains()` перед вызовом `removeChild()` в `setupScene()`
   - Добавлен флаг `_isRendering` для предотвращения конфликтов рендеринга

--- a/Components/CommunityGlobeParticipantManager.razor
+++ b/Components/CommunityGlobeParticipantManager.razor
@@ -178,7 +178,12 @@
                 RegisteredAt = DateTime.UtcNow
             };
 
-            await ParticipantRepository.AddParticipantAsync(participant);
+            var saveResult = await ParticipantRepository.AddParticipantAsync(participant);
+            if (!saveResult.Success)
+            {
+                ShowMessage($"❌ Ошибка сохранения: {saveResult.ErrorMessage}", true);
+                return;
+            }
 
             var participants = await ParticipantRepository.GetAllParticipantsAsync();
             var participantsList = participants.ToList();

--- a/Components/CommunityGlobeViewer.razor
+++ b/Components/CommunityGlobeViewer.razor
@@ -2,11 +2,13 @@
 @using ZealousMindedPeopleGeo.Services.Mapping
 @using ZealousMindedPeopleGeo.Services.Repositories
 @using ZealousMindedPeopleGeo.Services.GeoDataContainer
+@using ZealousMindedPeopleGeo.Services.Synchronization
 @inject IJSRuntime JSRuntime
 @inject GlobeStateService GlobeStateService
 @inject IGlobeMediator GlobeMediator
 @inject IParticipantRepository ParticipantRepository
 @inject IGeoDataContainerManager ContainerManager
+@inject IGeoDataChangeNotifier ChangeNotifier
 @implements IDisposable
 
 <HeadContent>
@@ -57,18 +59,52 @@
     private bool _isInitializing;
     private string? _errorMessage;
     private bool _isRendering;
+    private bool _isDisposed;
 
     protected override void OnInitialized()
     {
         GlobeStateService.OnStateChanged += HandleStateChanged;
+        ChangeNotifier.DataChanged += HandleGeoDataChanged;
     }
 
     private void HandleStateChanged(string globeId)
     {
         if (globeId == GlobeId)
         {
-            StateHasChanged();
+            _ = InvokeAsync(StateHasChanged);
         }
+    }
+
+    private void HandleGeoDataChanged(GeoDataChangeNotification notification)
+    {
+        if (_isDisposed || !IsRelevantDataChange(notification))
+        {
+            return;
+        }
+
+        _ = InvokeAsync(RefreshParticipantsAfterDataChangeAsync);
+    }
+
+    private bool IsRelevantDataChange(GeoDataChangeNotification notification)
+    {
+        if (!string.IsNullOrEmpty(DataContainerId))
+        {
+            return notification.Source == GeoDataChangeSource.Container &&
+                string.Equals(notification.ContainerId, DataContainerId, StringComparison.Ordinal);
+        }
+
+        return notification.Source == GeoDataChangeSource.ParticipantRepository;
+    }
+
+    private async Task RefreshParticipantsAfterDataChangeAsync()
+    {
+        if (_isDisposed || !State.IsInitialized)
+        {
+            return;
+        }
+
+        await LoadParticipantsAsync();
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -230,6 +266,8 @@
 
     public void Dispose()
     {
+        _isDisposed = true;
         GlobeStateService.OnStateChanged -= HandleStateChanged;
+        ChangeNotifier.DataChanged -= HandleGeoDataChanged;
     }
 }

--- a/Components/CommunityMapComponent.razor
+++ b/Components/CommunityMapComponent.razor
@@ -5,11 +5,13 @@
 @using System.Text.Json
 @using ZealousMindedPeopleGeo.Services
 @using ZealousMindedPeopleGeo.Services.Repositories
+@using ZealousMindedPeopleGeo.Services.Synchronization
 @using ZealousMindedPeopleGeo.Models
 @inject IJSRuntime JSRuntime
 @inject ILogger<CommunityMapComponent> Logger
 @inject IOptions<ZealousMindedPeopleGeoOptions> Options
 @inject IParticipantRepository ParticipantRepository
+@inject IGeoDataChangeNotifier ChangeNotifier
 @implements IAsyncDisposable
 
 <HeadContent>

--- a/Components/CommunityMapComponent.razor.cs
+++ b/Components/CommunityMapComponent.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using System.Text.Json;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Components;
 
@@ -25,7 +26,14 @@ public partial class CommunityMapComponent : IAsyncDisposable
     private Participant? SelectedParticipant;
     private IEnumerable<Participant> ParticipantsView = new List<Participant>();
     private bool _isLoading = true;
+    private bool _isMapInitialized;
+    private bool _isDisposed;
     private DotNetObjectReference<CommunityMapComponent>? _dotNetRef;
+
+    protected override void OnInitialized()
+    {
+        ChangeNotifier.DataChanged += HandleGeoDataChanged;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -59,6 +67,7 @@ public partial class CommunityMapComponent : IAsyncDisposable
                 centerLng,
                 zoom,
                 MapId);
+            _isMapInitialized = true;
 
             var participantsJson = JsonSerializer.Serialize(ParticipantsView);
             await JSRuntime.InvokeVoidAsync("loadParticipantsOnMap", participantsJson, MapId);
@@ -71,6 +80,38 @@ public partial class CommunityMapComponent : IAsyncDisposable
             Logger.LogError(ex, "Ошибка инициализации карты");
             _isLoading = false;
             StateHasChanged();
+        }
+    }
+
+    private void HandleGeoDataChanged(GeoDataChangeNotification notification)
+    {
+        if (_isDisposed ||
+            Participants != null ||
+            notification.Source != GeoDataChangeSource.ParticipantRepository)
+        {
+            return;
+        }
+
+        _ = InvokeAsync(ReloadRepositoryParticipantsAsync);
+    }
+
+    private async Task ReloadRepositoryParticipantsAsync()
+    {
+        if (_isDisposed || !_isMapInitialized)
+        {
+            return;
+        }
+
+        try
+        {
+            ParticipantsView = await ParticipantRepository.GetAllParticipantsAsync();
+            var participantsJson = JsonSerializer.Serialize(ParticipantsView);
+            await JSRuntime.InvokeVoidAsync("loadParticipantsOnMap", participantsJson, MapId);
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Ошибка обновления участников карты после изменения данных");
         }
     }
 
@@ -104,6 +145,9 @@ public partial class CommunityMapComponent : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        _isDisposed = true;
+        ChangeNotifier.DataChanged -= HandleGeoDataChanged;
+
         try
         {
             await JSRuntime.InvokeVoidAsync("disposeCommunityMap", MapId);

--- a/Components/GeoDataParticipantForm.razor
+++ b/Components/GeoDataParticipantForm.razor
@@ -189,14 +189,15 @@
             // 4. Добавление на глобус (если указан)
             if (!string.IsNullOrEmpty(GlobeId) && !string.IsNullOrEmpty(EffectiveGlobeContainerId))
             {
-                var globeResult = await GlobeMediator.AddParticipantAsync(EffectiveGlobeContainerId, participant);
+                var participants = (await container.GetAllParticipantsAsync()).ToList();
+                var globeResult = await GlobeMediator.AddParticipantsAsync(EffectiveGlobeContainerId, participants);
 
                 if (globeResult.Success)
                 {
                     GlobeStateService.UpdateState(GlobeId, s =>
                     {
-                        s.Participants.Add(participant);
-                        s.ParticipantCount = s.Participants.Count;
+                        s.Participants = participants;
+                        s.ParticipantCount = participants.Count;
                     });
                     Logger.LogInformation("Participant '{Name}' added to globe '{GlobeId}'", participant.Name, GlobeId);
                 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **3D глобус сообщества** - Трехмерная визуализация планеты с интерактивными точками участников
 - **Настройки глобуса** - Полная настройка параметров глобуса (размеры, освещение, атмосфера, облака)
 - **Динамическое управление** - Включение/выключение атмосферы и облаков в реальном времени
+- **Синхронизация между пользователями** - Изменения точек обновляются у активных пользователей без постоянного опроса
 - **Множественные глобусы** - Поддержка нескольких независимых 3D глобусов на одной странице
 - **Именованные контейнеры гео-данных** - Удобная организация данных в именованных контейнерах для разных глобусов
 - **Управление состоянием** - Централизованное управление состоянием всех глобусов
@@ -564,6 +565,29 @@ private void HandleDataChanged(string containerId, GeoDataChangeType changeType)
     Console.WriteLine($"Container '{containerId}' changed: {changeType}");
     // GeoDataChangeType: Added, Updated, Removed, Cleared, BulkLoaded
 }
+```
+
+### Автоматическая синхронизация без polling
+
+`AddZealousMindedPeopleGeo(...)`, `AddZealousMindedPeopleGeoServices()`,
+`AddGeoDataContainers()` и `AddGeoDataDatabase(...)` регистрируют общий
+`IGeoDataChangeNotifier`. Встроенные контейнеры и репозитории публикуют изменения
+через него, а активные компоненты Blazor обновляют отображение через обычный
+рендеринг Blazor:
+
+- `CommunityGlobeViewer` с `DataContainerId` перезагружает точки при изменении этого контейнера;
+- `CommunityGlobeViewer` без `DataContainerId` перезагружает точки при изменении общего `IParticipantRepository`;
+- `CommunityMapComponent` без явного параметра `Participants` обновляет маркеры при изменении общего `IParticipantRepository`.
+
+Для собственных репозиториев участников публикуйте событие после успешной записи:
+
+```csharp
+@inject IGeoDataChangeNotifier ChangeNotifier
+
+ChangeNotifier.Publish(
+    GeoDataChangeNotification.ForParticipantRepository(
+        GeoDataChangeType.Added,
+        participant.Id));
 ```
 
 ## 🗄️ Хранение гео-данных в базе данных

--- a/ServiceCollectionExtensions.cs
+++ b/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ namespace ZealousMindedPeopleGeo
             services.AddScoped<IGeocodingService, GoogleMapsGeocodingService>();
             services.AddScoped<IMapService, GoogleMapsServiceAdapter>();
             services.AddScoped<ICachingService, CachingService>();
+            services.AddGeoDataContainers();
 
             return services;
         }
@@ -65,7 +66,7 @@ namespace ZealousMindedPeopleGeo
             });
 
             // Регистрация сервисов с зависимостями
-            services.AddScoped<IParticipantRepository, InMemoryParticipantRepository>();
+            services.AddSingleton<IParticipantRepository, InMemoryParticipantRepository>();
             services.AddScoped<IThreeJsGlobeService, ThreeJsGlobeService>();
             services.AddScoped<IGlobeMediator, GlobeMediatorService>();
             services.AddScoped<GlobeStateService>();
@@ -107,6 +108,7 @@ namespace ZealousMindedPeopleGeo
             services.AddScoped<IGoogleMapsService, GoogleMapsService>();
             services.AddScoped<IParticipantService, ParticipantService>();
             services.AddScoped<ICachingService, CachingService>();
+            services.AddGeoDataContainers();
 
             return services;
         }

--- a/Services/GeoDataContainer/GeoDataContainerManager.cs
+++ b/Services/GeoDataContainer/GeoDataContainerManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
 
@@ -17,10 +18,12 @@ public class GeoDataContainerManager : GeoDataContainerManagerBase
     /// </summary>
     /// <param name="logger">Логгер</param>
     /// <param name="loggerFactory">Фабрика логгеров для создания логгеров контейнеров</param>
+    /// <param name="changeNotifier">Общий уведомитель изменений гео-данных</param>
     public GeoDataContainerManager(
         ILogger<GeoDataContainerManager> logger,
-        ILoggerFactory loggerFactory)
-        : base(logger)
+        ILoggerFactory loggerFactory,
+        IGeoDataChangeNotifier? changeNotifier = null)
+        : base(logger, changeNotifier)
     {
         _loggerFactory = loggerFactory;
     }

--- a/Services/GeoDataContainer/GeoDataContainerManagerBase.cs
+++ b/Services/GeoDataContainer/GeoDataContainerManagerBase.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
 
@@ -16,6 +17,8 @@ public abstract class GeoDataContainerManagerBase : IGeoDataContainerManager
     /// Логгер менеджера контейнеров
     /// </summary>
     protected ILogger Logger { get; }
+
+    private readonly IGeoDataChangeNotifier? _changeNotifier;
 
     /// <summary>
     /// Опции сериализации для экспорта данных в JSON
@@ -41,9 +44,13 @@ public abstract class GeoDataContainerManagerBase : IGeoDataContainerManager
     /// Создает новый базовый менеджер контейнеров
     /// </summary>
     /// <param name="logger">Логгер</param>
-    protected GeoDataContainerManagerBase(ILogger logger)
+    /// <param name="changeNotifier">Общий уведомитель изменений гео-данных</param>
+    protected GeoDataContainerManagerBase(
+        ILogger logger,
+        IGeoDataChangeNotifier? changeNotifier = null)
     {
         Logger = logger;
+        _changeNotifier = changeNotifier;
     }
 
     /// <inheritdoc />
@@ -193,14 +200,21 @@ public abstract class GeoDataContainerManagerBase : IGeoDataContainerManager
     /// <param name="changeType">Тип изменения</param>
     protected void HandleDataChanged(string containerId, GeoDataChangeType changeType)
     {
-        try
+        Logger.LogDebug("Data changed in container '{ContainerId}': {ChangeType}", containerId, changeType);
+
+        foreach (var subscriber in OnDataChanged?.GetInvocationList().Cast<Action<string, GeoDataChangeType>>() ??
+            Enumerable.Empty<Action<string, GeoDataChangeType>>())
         {
-            Logger.LogDebug("Data changed in container '{ContainerId}': {ChangeType}", containerId, changeType);
-            OnDataChanged?.Invoke(containerId, changeType);
+            try
+            {
+                subscriber(containerId, changeType);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Geo-data container subscriber failed for container '{ContainerId}'", containerId);
+            }
         }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error handling data change event for container '{ContainerId}'", containerId);
-        }
+
+        _changeNotifier?.Publish(GeoDataChangeNotification.ForContainer(containerId, changeType));
     }
 }

--- a/Services/GeoDataContainer/GeoDataLoaderExtensions.cs
+++ b/Services/GeoDataContainer/GeoDataLoaderExtensions.cs
@@ -1,9 +1,11 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using ZealousMindedPeopleGeo.Models;
 using ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
 using ZealousMindedPeopleGeo.Services.Mapping;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer;
 
@@ -20,7 +22,8 @@ public static class GeoDataLoaderExtensions
     /// <returns>Коллекция сервисов для цепочки вызовов</returns>
     public static IServiceCollection AddGeoDataContainers(this IServiceCollection services)
     {
-        services.AddSingleton<IGeoDataContainerManager, GeoDataContainerManager>();
+        services.AddGeoDataChangeNotifications();
+        services.TryAddSingleton<IGeoDataContainerManager, GeoDataContainerManager>();
         return services;
     }
 
@@ -46,6 +49,8 @@ public static class GeoDataLoaderExtensions
         Action<DbContextOptionsBuilder> configureDbContext)
     {
         ArgumentNullException.ThrowIfNull(configureDbContext);
+
+        services.AddGeoDataChangeNotifications();
 
         // Фабрика контекстов безопасна для многопоточной среды (в т.ч. Blazor)
         services.AddDbContextFactory<GeoDataDbContext>(configureDbContext);
@@ -282,16 +287,17 @@ public class GlobeDataInitializer
                 return addResult;
             }
 
-            // 3. Добавляем участника на глобус
-            var globeResult = await _globeMediator.AddParticipantAsync(htmlContainerId, participant);
+            // 3. Обновляем глобус полным текущим набором, чтобы удалить устаревшие точки
+            var participants = (await container.GetAllParticipantsAsync(ct)).ToList();
+            var globeResult = await _globeMediator.AddParticipantsAsync(htmlContainerId, participants);
 
             if (globeResult.Success)
             {
                 // 4. Обновляем состояние
                 _globeStateService.UpdateState(globeId, s =>
                 {
-                    s.Participants.Add(participant);
-                    s.ParticipantCount = s.Participants.Count;
+                    s.Participants = participants;
+                    s.ParticipantCount = participants.Count;
                 });
             }
 

--- a/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainerManager.cs
+++ b/Services/GeoDataContainer/Persistence/DatabaseGeoDataContainerManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.GeoDataContainer.Persistence;
 
@@ -22,11 +23,13 @@ public class DatabaseGeoDataContainerManager : GeoDataContainerManagerBase
     /// <param name="contextFactory">Фабрика контекстов БД</param>
     /// <param name="logger">Логгер</param>
     /// <param name="loggerFactory">Фабрика логгеров для создания логгеров контейнеров</param>
+    /// <param name="changeNotifier">Общий уведомитель изменений гео-данных</param>
     public DatabaseGeoDataContainerManager(
         IDbContextFactory<GeoDataDbContext> contextFactory,
         ILogger<DatabaseGeoDataContainerManager> logger,
-        ILoggerFactory loggerFactory)
-        : base(logger)
+        ILoggerFactory loggerFactory,
+        IGeoDataChangeNotifier? changeNotifier = null)
+        : base(logger, changeNotifier)
     {
         _contextFactory = contextFactory;
         _loggerFactory = loggerFactory;

--- a/Services/Mapping/GlobeMediatorService.cs
+++ b/Services/Mapping/GlobeMediatorService.cs
@@ -71,8 +71,8 @@ public class GlobeMediatorService : IGlobeMediator
             if (isGlobeAvailable)
             {
                 // 3D глобус доступен - добавляем через него
-                _logger.LogInformation("🎯 Глобус доступен, вызываем AddParticipantsAsync для контейнера: {ContainerId}", containerId);
-                result = await _globeService.AddParticipantsAsync(containerId, new[] { participant });
+                _logger.LogInformation("🎯 Глобус доступен, вызываем AddParticipantAsync для контейнера: {ContainerId}", containerId);
+                result = await _globeService.AddParticipantAsync(containerId, participant);
                 if (result.Success)
                 {
                     _logger.LogInformation("✅ Участник {Name} успешно добавлен в глобус {ContainerId}", participant.Name, containerId);

--- a/Services/Mapping/IThreeJsGlobeService.cs
+++ b/Services/Mapping/IThreeJsGlobeService.cs
@@ -17,6 +17,15 @@ public interface IThreeJsGlobeService
     ValueTask<Models.GlobeInitializationResult> InitializeGlobeAsync(string containerId, Models.GlobeOptions options, CancellationToken ct = default);
 
     /// <summary>
+    /// Добавляет одного участника на глобус
+    /// </summary>
+    /// <param name="containerId">ID контейнера глобуса</param>
+    /// <param name="participant">Данные участника</param>
+    /// <param name="ct">Токен отмены операции</param>
+    /// <returns>Результат добавления</returns>
+    ValueTask<Models.GlobeOperationResult> AddParticipantAsync(string containerId, Models.Participant participant, CancellationToken ct = default);
+
+    /// <summary>
     /// Добавляет участников на глобус
     /// </summary>
     /// <param name="containerId">ID контейнера глобуса</param>

--- a/Services/Mapping/ThreeJsGlobeService.cs
+++ b/Services/Mapping/ThreeJsGlobeService.cs
@@ -86,6 +86,46 @@ public class ThreeJsGlobeService : IThreeJsGlobeService, IAsyncDisposable
         }
     }
 
+    public async ValueTask<GlobeOperationResult> AddParticipantAsync(string containerId, Participant participant, CancellationToken ct = default)
+    {
+        if (participant == null)
+        {
+            return new GlobeOperationResult { Success = false, ErrorMessage = "Participant cannot be null" };
+        }
+
+        try
+        {
+            if (_module == null)
+            {
+                return new GlobeOperationResult { Success = false, ErrorMessage = "Globe module not initialized" };
+            }
+
+            var participantData = new
+            {
+                id = participant.Id.ToString(),
+                participant.Name,
+                participant.Latitude,
+                participant.Longitude,
+                location = $"{participant.Name} ({participant.Latitude:F4}, {participant.Longitude:F4})"
+            };
+
+            var success = await _module.InvokeAsync<bool>("addParticipant", containerId, participantData);
+
+            if (success)
+            {
+                _logger.LogInformation("✅ Добавлен участник {Name} в глобус {ContainerId}", participant.Name, containerId);
+                return new GlobeOperationResult { Success = true, ProcessedCount = 1 };
+            }
+
+            return new GlobeOperationResult { Success = false, ErrorMessage = "Participant already exists or globe instance not found" };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "❌ Ошибка при добавлении участника {Name} в контейнер {ContainerId}", participant.Name, containerId);
+            return new GlobeOperationResult { Success = false, ErrorMessage = ex.Message };
+        }
+    }
+
     public async ValueTask<GlobeOperationResult> AddParticipantsAsync(string containerId, IEnumerable<Participant> participants, CancellationToken ct = default)
     {
         if (participants == null)

--- a/Services/ParticipantService.cs
+++ b/Services/ParticipantService.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services;
 
@@ -13,17 +15,20 @@ public class ParticipantService : IParticipantService
     private readonly IGoogleMapsService _mapsService;
     private readonly ZealousMindedPeopleGeoOptions _options;
     private readonly ILogger<ParticipantService> _logger;
+    private readonly IGeoDataChangeNotifier? _changeNotifier;
 
     public ParticipantService(
         IGoogleSheetsService sheetsService,
         IGoogleMapsService mapsService,
         IOptions<ZealousMindedPeopleGeoOptions> options,
-        ILogger<ParticipantService> logger)
+        ILogger<ParticipantService> logger,
+        IGeoDataChangeNotifier? changeNotifier = null)
     {
         _sheetsService = sheetsService;
         _mapsService = mapsService;
         _options = options.Value;
         _logger = logger;
+        _changeNotifier = changeNotifier;
     }
 
     public async Task<RegistrationResult> RegisterParticipantAsync(ParticipantRegistrationModel model)
@@ -94,6 +99,9 @@ public class ParticipantService : IParticipantService
             }
 
             _logger.LogInformation("Участник {Name} успешно зарегистрирован", participant.Name);
+            _changeNotifier?.Publish(GeoDataChangeNotification.ForParticipantRepository(
+                GeoDataChangeType.Added,
+                participant.Id));
 
             return new RegistrationResult
             {

--- a/Services/Repositories/GoogleSheetsParticipantRepository.cs
+++ b/Services/Repositories/GoogleSheetsParticipantRepository.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.Repositories
 {
@@ -12,15 +14,18 @@ namespace ZealousMindedPeopleGeo.Services.Repositories
         private readonly ZealousMindedPeopleGeoOptions _options;
         private readonly ILogger<GoogleSheetsParticipantRepository> _logger;
         private readonly IGoogleSheetsService _googleSheetsService;
+        private readonly IGeoDataChangeNotifier? _changeNotifier;
 
         public GoogleSheetsParticipantRepository(
             IOptions<ZealousMindedPeopleGeoOptions> options,
             ILogger<GoogleSheetsParticipantRepository> logger,
-            IGoogleSheetsService googleSheetsService)
+            IGoogleSheetsService googleSheetsService,
+            IGeoDataChangeNotifier? changeNotifier = null)
         {
             _options = options.Value;
             _logger = logger;
             _googleSheetsService = googleSheetsService;
+            _changeNotifier = changeNotifier;
         }
 
         public async ValueTask<RepositoryResult> AddParticipantAsync(Participant participant, CancellationToken ct = default)
@@ -31,6 +36,10 @@ namespace ZealousMindedPeopleGeo.Services.Repositories
 
                 if (sheetResult.Success)
                 {
+                    _changeNotifier?.Publish(GeoDataChangeNotification.ForParticipantRepository(
+                        GeoDataChangeType.Added,
+                        participant.Id));
+
                     return new RepositoryResult
                     {
                         Success = true,

--- a/Services/Repositories/InMemoryParticipantRepository.cs
+++ b/Services/Repositories/InMemoryParticipantRepository.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using ZealousMindedPeopleGeo.Services.Synchronization;
 
 namespace ZealousMindedPeopleGeo.Services.Repositories;
 
@@ -12,10 +14,14 @@ public class InMemoryParticipantRepository : IParticipantRepository
 {
     private readonly ConcurrentDictionary<Guid, Participant> _participants = new();
     private readonly ILogger<InMemoryParticipantRepository> _logger;
+    private readonly IGeoDataChangeNotifier? _changeNotifier;
 
-    public InMemoryParticipantRepository(ILogger<InMemoryParticipantRepository> logger)
+    public InMemoryParticipantRepository(
+        ILogger<InMemoryParticipantRepository> logger,
+        IGeoDataChangeNotifier? changeNotifier = null)
     {
         _logger = logger;
+        _changeNotifier = changeNotifier;
     }
 
     public ValueTask<RepositoryResult> AddParticipantAsync(Participant participant, CancellationToken ct = default)
@@ -44,6 +50,7 @@ public class InMemoryParticipantRepository : IParticipantRepository
             _participants[participant.Id] = participant;
 
             _logger.LogInformation("Participant {Name} added with ID {Id}", participant.Name, participant.Id);
+            PublishChange(GeoDataChangeType.Added, participant.Id);
 
             return ValueTask.FromResult(new RepositoryResult
             {
@@ -127,6 +134,7 @@ public class InMemoryParticipantRepository : IParticipantRepository
             _participants[participant.Id] = participant;
 
             _logger.LogInformation("Participant {Name} updated with ID {Id}", participant.Name, participant.Id);
+            PublishChange(GeoDataChangeType.Updated, participant.Id);
 
             return ValueTask.FromResult(new RepositoryResult
             {
@@ -153,6 +161,7 @@ public class InMemoryParticipantRepository : IParticipantRepository
             if (_participants.TryRemove(id, out var removedParticipant))
             {
                 _logger.LogInformation("Participant {Name} deleted with ID {Id}", removedParticipant.Name, id);
+                PublishChange(GeoDataChangeType.Removed, id);
 
                 return ValueTask.FromResult(new RepositoryResult
                 {
@@ -195,5 +204,14 @@ public class InMemoryParticipantRepository : IParticipantRepository
     /// <summary>
     /// Очищает все данные (для тестирования)
     /// </summary>
-    public void ClearAll() => _participants.Clear();
+    public void ClearAll()
+    {
+        _participants.Clear();
+        PublishChange(GeoDataChangeType.Cleared, null);
+    }
+
+    private void PublishChange(GeoDataChangeType changeType, Guid? participantId)
+    {
+        _changeNotifier?.Publish(GeoDataChangeNotification.ForParticipantRepository(changeType, participantId));
+    }
 }

--- a/Services/Synchronization/GeoDataChangeNotification.cs
+++ b/Services/Synchronization/GeoDataChangeNotification.cs
@@ -1,0 +1,46 @@
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+
+namespace ZealousMindedPeopleGeo.Services.Synchronization;
+
+/// <summary>
+/// Describes a geo-data change that active Blazor components can react to.
+/// </summary>
+/// <param name="Source">Origin of the change.</param>
+/// <param name="ChangeType">Kind of data mutation.</param>
+/// <param name="ContainerId">Changed geo-data container ID, when the source is a container.</param>
+/// <param name="ParticipantId">Changed participant ID, when available.</param>
+/// <param name="ChangedAtUtc">UTC timestamp when the notification was created.</param>
+public sealed record GeoDataChangeNotification(
+    GeoDataChangeSource Source,
+    GeoDataChangeType ChangeType,
+    string? ContainerId,
+    Guid? ParticipantId,
+    DateTimeOffset ChangedAtUtc)
+{
+    public static GeoDataChangeNotification ForContainer(
+        string containerId,
+        GeoDataChangeType changeType,
+        Guid? participantId = null)
+        => new(
+            GeoDataChangeSource.Container,
+            changeType,
+            containerId,
+            participantId,
+            DateTimeOffset.UtcNow);
+
+    public static GeoDataChangeNotification ForParticipantRepository(
+        GeoDataChangeType changeType,
+        Guid? participantId = null)
+        => new(
+            GeoDataChangeSource.ParticipantRepository,
+            changeType,
+            null,
+            participantId,
+            DateTimeOffset.UtcNow);
+}
+
+public enum GeoDataChangeSource
+{
+    Container,
+    ParticipantRepository
+}

--- a/Services/Synchronization/GeoDataChangeNotifier.cs
+++ b/Services/Synchronization/GeoDataChangeNotifier.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+
+namespace ZealousMindedPeopleGeo.Services.Synchronization;
+
+/// <summary>
+/// Process-wide change bus for geo-data updates.
+/// In Blazor Server, component subscribers are re-rendered through the normal circuit transport.
+/// </summary>
+public sealed class GeoDataChangeNotifier : IGeoDataChangeNotifier
+{
+    private readonly ILogger<GeoDataChangeNotifier> _logger;
+
+    public GeoDataChangeNotifier(ILogger<GeoDataChangeNotifier> logger)
+    {
+        _logger = logger;
+    }
+
+    public event Action<GeoDataChangeNotification>? DataChanged;
+
+    public void Publish(GeoDataChangeNotification notification)
+    {
+        var subscribers = DataChanged;
+        if (subscribers == null)
+        {
+            return;
+        }
+
+        foreach (var subscriber in subscribers.GetInvocationList().Cast<Action<GeoDataChangeNotification>>())
+        {
+            try
+            {
+                subscriber(notification);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Geo-data change subscriber failed for source {Source} and change {ChangeType}",
+                    notification.Source,
+                    notification.ChangeType);
+            }
+        }
+    }
+}

--- a/Services/Synchronization/GeoDataSynchronizationServiceCollectionExtensions.cs
+++ b/Services/Synchronization/GeoDataSynchronizationServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace ZealousMindedPeopleGeo.Services.Synchronization;
+
+public static class GeoDataSynchronizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the shared notifier used by Blazor components to refresh after data changes.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <returns>Service collection for chaining.</returns>
+    public static IServiceCollection AddGeoDataChangeNotifications(this IServiceCollection services)
+    {
+        services.TryAddSingleton<IGeoDataChangeNotifier, GeoDataChangeNotifier>();
+        return services;
+    }
+}

--- a/Services/Synchronization/IGeoDataChangeNotifier.cs
+++ b/Services/Synchronization/IGeoDataChangeNotifier.cs
@@ -1,0 +1,11 @@
+namespace ZealousMindedPeopleGeo.Services.Synchronization;
+
+/// <summary>
+/// Publishes geo-data changes to active Blazor components without polling.
+/// </summary>
+public interface IGeoDataChangeNotifier
+{
+    event Action<GeoDataChangeNotification>? DataChanged;
+
+    void Publish(GeoDataChangeNotification notification);
+}

--- a/ZealousMindedPeopleGeo.csproj
+++ b/ZealousMindedPeopleGeo.csproj
@@ -8,7 +8,7 @@
 
     <!-- Информация о пакете -->
     <PackageId>ZealousMindedPeopleGeo</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Zealous Minded People Community</Authors>
     <Company>Zealous Minded People</Company>
     <Description>Библиотека для создания интерактивных географических приложений сообщества людей, объединенных стремлением сделать мир добрее и гармоничнее. Включает карты, 3D глобус, геокодирование, PWA поддержку и многое другое.</Description>
@@ -18,6 +18,7 @@
       ✨ Возможности:
       • Интерактивная карта сообщества на Google Maps
       • 3D глобус с Three.js и интерактивным управлением
+      • Синхронизация изменений между пользователями без постоянного опроса
       • Геокодирование через Nominatim OpenStreetMap API
       • Гибкие источники данных (In-Memory, Google Sheets, JSON)
       • Полная PWA поддержка с оффлайн функциональностью
@@ -33,7 +34,7 @@
 
       📚 Подробная документация: https://github.com/zealousmindedpeople/geo-library
     </PackageDescription>
-    <PackageTags>geography;maps;community;blazor;threejs;pwa;geocoding;localization;validation;caching</PackageTags>
+    <PackageTags>geography;maps;community;blazor;threejs;pwa;geocoding;localization;validation;caching;realtime;synchronization</PackageTags>
     <PackageProjectUrl>https://github.com/zealousmindedpeople/geo-library</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- Иконка пакета будет добавлена позже -->
@@ -41,6 +42,14 @@
     <RepositoryUrl>https://github.com/zealousmindedpeople/geo-library.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>
+      v1.2.0
+
+      - Добавлена синхронизация изменений гео-данных между активными Blazor-пользователями без polling.
+      - Новый общий уведомитель IGeoDataChangeNotifier публикует изменения контейнеров и встроенных репозиториев.
+      - CommunityGlobeViewer и CommunityMapComponent автоматически обновляют точки при релевантных изменениях.
+      - InMemoryParticipantRepository в тестовой регистрации теперь singleton, чтобы данные были общими между пользователями.
+      - Исправлен путь одиночного добавления точки на 3D-глобус: существующие маркеры больше не заменяются одной новой точкой.
+
       v1.1.0
 
       - Новый компонент LibraryShowcaseComponent — единая витрина всех возможностей библиотеки

--- a/tests/ZealousMindedPeopleGeo.Tests/GeoDataChangeNotifierTests.cs
+++ b/tests/ZealousMindedPeopleGeo.Tests/GeoDataChangeNotifierTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.DependencyInjection;
+using ZealousMindedPeopleGeo.Models;
+using ZealousMindedPeopleGeo.Services.GeoDataContainer;
+using ZealousMindedPeopleGeo.Services.Repositories;
+using ZealousMindedPeopleGeo.Services.Synchronization;
+using Xunit;
+
+namespace ZealousMindedPeopleGeo.Tests;
+
+public class GeoDataChangeNotifierTests
+{
+    [Fact]
+    public async Task InMemoryContainerChange_PublishesContainerNotification()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGeoDataContainers();
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<IGeoDataChangeNotifier>();
+        var notifications = new List<GeoDataChangeNotification>();
+        notifier.DataChanged += notifications.Add;
+
+        var manager = provider.GetRequiredService<IGeoDataContainerManager>();
+        await manager.GetOrCreateContainer("shared").AddParticipantAsync(CreateParticipant("Shared"));
+
+        Assert.Contains(notifications, notification =>
+            notification.Source == GeoDataChangeSource.Container &&
+            notification.ContainerId == "shared" &&
+            notification.ChangeType == GeoDataChangeType.Added);
+    }
+
+    [Fact]
+    public async Task InMemoryContainerChange_PublishesNotificationWhenLegacySubscriberThrows()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGeoDataContainers();
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<IGeoDataChangeNotifier>();
+        var notifications = new List<GeoDataChangeNotification>();
+        notifier.DataChanged += notifications.Add;
+
+        var manager = provider.GetRequiredService<IGeoDataContainerManager>();
+        manager.OnDataChanged += (_, _) => throw new InvalidOperationException("Legacy subscriber failed");
+
+        await manager.GetOrCreateContainer("shared").AddParticipantAsync(CreateParticipant("Shared"));
+
+        Assert.Contains(notifications, notification =>
+            notification.Source == GeoDataChangeSource.Container &&
+            notification.ContainerId == "shared" &&
+            notification.ChangeType == GeoDataChangeType.Added);
+    }
+
+    [Fact]
+    public async Task InMemoryParticipantRepositoryChanges_PublishRepositoryNotifications()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGeoDataChangeNotifications();
+        services.AddSingleton<IParticipantRepository, InMemoryParticipantRepository>();
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<IGeoDataChangeNotifier>();
+        var notifications = new List<GeoDataChangeNotification>();
+        notifier.DataChanged += notifications.Add;
+
+        var repository = provider.GetRequiredService<IParticipantRepository>();
+        var participant = CreateParticipant("Repository");
+
+        await repository.AddParticipantAsync(participant);
+        participant.Name = "Repository Updated";
+        await repository.UpdateParticipantAsync(participant);
+        await repository.DeleteParticipantAsync(participant.Id);
+
+        Assert.Contains(notifications, notification =>
+            notification.Source == GeoDataChangeSource.ParticipantRepository &&
+            notification.ChangeType == GeoDataChangeType.Added &&
+            notification.ParticipantId == participant.Id);
+        Assert.Contains(notifications, notification =>
+            notification.Source == GeoDataChangeSource.ParticipantRepository &&
+            notification.ChangeType == GeoDataChangeType.Updated &&
+            notification.ParticipantId == participant.Id);
+        Assert.Contains(notifications, notification =>
+            notification.Source == GeoDataChangeSource.ParticipantRepository &&
+            notification.ChangeType == GeoDataChangeType.Removed &&
+            notification.ParticipantId == participant.Id);
+    }
+
+    [Fact]
+    public void Publish_ContinuesWhenSubscriberThrows()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGeoDataChangeNotifications();
+
+        using var provider = services.BuildServiceProvider();
+        var notifier = provider.GetRequiredService<IGeoDataChangeNotifier>();
+        GeoDataChangeNotification? received = null;
+
+        notifier.DataChanged += _ => throw new InvalidOperationException("Subscriber failed");
+        notifier.DataChanged += notification => received = notification;
+
+        var expected = GeoDataChangeNotification.ForContainer("shared", GeoDataChangeType.Updated);
+        notifier.Publish(expected);
+
+        Assert.Same(expected, received);
+    }
+
+    private static Participant CreateParticipant(string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Email = $"{name.ToLowerInvariant()}@example.com",
+        Address = "Test Address",
+        Location = "Test Location",
+        Latitude = 55.7558,
+        Longitude = 37.6176
+    };
+}

--- a/wwwroot/js/community-globe.js
+++ b/wwwroot/js/community-globe.js
@@ -2505,6 +2505,27 @@ export function addParticipants(containerId, participants) {
     }
 }
 
+/**
+ * Добавляет одного участника на глобус, сохраняя существующие точки.
+ * @param {string} containerId - ID контейнера глобуса
+ * @param {Object} participant - Объект участника
+ * @returns {boolean} true если участник успешно добавлен
+ */
+export function addParticipant(containerId, participant) {
+    try {
+        console.log('🔄 Добавление одного участника на глобус', containerId, ':', participant?.name);
+        const globe = globeInstances.get(containerId);
+        if (globe && globe.state && globe.state.isInitialized) {
+            return globe.addTestParticipant(participant);
+        }
+        console.log('❌ Глобус', containerId, 'не инициализирован');
+        return false;
+    } catch (error) {
+        console.error('Error adding participant to globe', containerId, ':', error);
+        return false;
+    }
+}
+
 export function updateParticipantPosition(containerId, participantId, latitude, longitude) {
     try {
         const globe = globeInstances.get(containerId);


### PR DESCRIPTION
## Что сделано

Реализована синхронизация изменений гео-данных между активными пользователями Blazor без постоянного polling.

Closes #57

### Новое

- Добавлен общий `IGeoDataChangeNotifier` - singleton-уведомитель изменений гео-данных внутри Blazor-приложения.
- `GeoDataContainerManager` и `DatabaseGeoDataContainerManager` публикуют изменения контейнеров через общий notifier.
- Встроенные репозитории участников публикуют успешные изменения: добавление, обновление, удаление и очистку.
- `CommunityGlobeViewer` автоматически перезагружает точки:
  - по `DataContainerId`, если глобус привязан к именованному контейнеру;
  - по `IParticipantRepository`, если глобус использует общий репозиторий.
- `CommunityMapComponent` автоматически обновляет маркеры при изменении общего `IParticipantRepository`, если компоненту не передан явный `Participants`.
- `InMemoryParticipantRepository` в тестовой регистрации переведен на singleton, чтобы данные были общими между активными пользователями.

### Дополнительно

- Исправлен путь одиночного добавления точки на 3D-глобус: `GlobeMediatorService.AddParticipantAsync` теперь вызывает новый JS export `addParticipant`, который сохраняет уже отображенные маркеры.
- Формы и helper-сервис контейнеров после сохранения обновляют глобус полным актуальным набором данных.
- Обновлены README, CHANGELOG и версия пакета до `1.2.0`.

## Как воспроизвести / проверить

1. Открыть страницу с `CommunityGlobeViewer` в двух активных Blazor-сессиях.
2. Добавить участника через встроенный менеджер, форму или контейнерный API.
3. Второй активный глобус/карта получает обновленный набор точек через событие notifier, без таймера и без polling.

## Тесты

Добавлены xUnit-тесты `GeoDataChangeNotifierTests`:

- изменение in-memory контейнера публикует container notification;
- notification публикуется даже если старый `OnDataChanged` подписчик бросает исключение;
- изменения `InMemoryParticipantRepository` публикуют repository notifications;
- один падающий подписчик notifier не блокирует остальных.

Локально выполнено:

```bash
git diff --check
```

`dotnet test tests/ZealousMindedPeopleGeo.Tests/ZealousMindedPeopleGeo.Tests.csproj --logger "console;verbosity=minimal"` не дошел до компиляции в этом runner, потому что установлен только .NET SDK `8.0.126`, а проект таргетит `net10.0`:

```text
error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.
```